### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/app/models/validators.py
+++ b/app/models/validators.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from decimal import Decimal
 from typing import Optional
+from urllib.parse import urlparse
 
 from app.db.models import UserStatusCreate
 
@@ -173,8 +174,11 @@ class ProxyValidator:
 class DiscordValidator:
     @staticmethod
     def validate_webhook(value: str | None):
-        if value and not value.startswith("https://discord.com"):
-            raise ValueError("Discord webhook must start with 'https://discord.com'")
+        if value:
+            parsed = urlparse(value)
+            # validate scheme and hostname
+            if parsed.scheme != "https" or parsed.hostname not in {"discord.com"}:
+                raise ValueError("Discord webhook must use https scheme and point to 'discord.com'")
         return value
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/PasarGuard/panel/security/code-scanning/2](https://github.com/PasarGuard/panel/security/code-scanning/2)

To fix the problem, update the Discord webhook URL validation to robustly check the hostname using URL parsing rather than simple string matching. Specifically:
- Parse the URL using `urllib.parse.urlparse`.
- Verify that the scheme is HTTPS and the `netloc`/host is either exactly `discord.com` or a documented canonical subdomain (if allowed), such as `discord.com` (and optionally `discordapp.com` if relevant).
- Reject URLs that do not meet these requirements.
- Make these changes within `class DiscordValidator`, specifically in the `validate_webhook` method, replacing the string prefix check.

You'll need to:
- Import `urlparse` from `urllib.parse` (if not present).
- Adjust the method to parse the URL, handle possible errors (such as poorly formed URLs), and ensure the host and scheme are as required.
- Only accept the webhook URL if both the scheme and host match.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
