### PR TITLE
Persian (fa) Translation Updates

### DIFF
--- a/dashboard/public/statics/locales/fa.json
+++ b/dashboard/public/statics/locales/fa.json
@@ -18,7 +18,7 @@
   "groups": "گروه‌ها",
   "documentation": "مستندات",
   "discussionGroup": "گروه گفتگو",
-  "github": "گیت‌هاب",
+  "github": "GitHub",
   "community": "جامعه",
   "supportUs": "پشتیبانی از ما",
   "manageHosts": "مدیریت و کنترل هاست‌ها",
@@ -30,7 +30,7 @@
     "title": "تنظیمات",
     "notifications": {
       "title": "اعلان‌ها",
-      "description": "پیکربندی تنظیمات اعلان‌های تلگرام و دیسکورد",
+      "description": "پیکربندی تنظیمات اعلان‌های تلگرام و Discord",
       "loadError": "بارگیری تنظیمات اعلان‌ها ناموفق بود",
       "saveSuccess": "تنظیمات اعلان‌ها با موفقیت ذخیره شد",
       "saveFailed": "ذخیره تنظیمات اعلان‌ها ناموفق بود",
@@ -58,9 +58,9 @@
         "topicId": "شناسه موضوع"
       },
       "discord": {
-        "title": "دیسکورد",
-        "description": "تنظیم اعلان‌های وبهوک دیسکورد برای دریافت هشدارها مستقیماً در کانال‌های سرور دیسکورد شما",
-        "webhookUrl": "آدرس وبهوک"
+        "title": "Discord",
+        "description": "تنظیم اعلان‌های webhook Discord برای دریافت هشدارها مستقیماً در کانال‌های سرور Discord شما",
+        "webhookUrl": "آدرس webhook"
       },
       "advanced": {
         "title": "تنظیمات پیشرفته",
@@ -180,19 +180,19 @@
       }
     },
     "discord": {
-      "title": "دیسکورد",
-      "description": "تنظیم یکپارچگی ربات دیسکورد و تنظیمات مرتبط برای سیستم شما",
-      "loadError": "بارگذاری تنظیمات دیسکورد ناموفق بود. لطفاً دوباره تلاش کنید.",
-      "saveSuccess": "تنظیمات دیسکورد با موفقیت ذخیره شد",
-      "saveFailed": "ذخیره تنظیمات دیسکورد ناموفق بود",
-      "cancelSuccess": "تغییرات لغو شد و تنظیمات اصلی دیسکورد بازیابی شد",
+      "title": "Discord",
+      "description": "تنظیم یکپارچگی ربات Discord و تنظیمات مرتبط برای سیستم شما",
+      "loadError": "بارگذاری تنظیمات Discord ناموفق بود. لطفاً دوباره تلاش کنید.",
+      "saveSuccess": "تنظیمات Discord با موفقیت ذخیره شد",
+      "saveFailed": "ذخیره تنظیمات Discord ناموفق بود",
+      "cancelSuccess": "تغییرات لغو شد و تنظیمات اصلی Discord بازیابی شد",
       "general": {
         "title": "تنظیمات عمومی",
-        "description": "پیکربندی اولیه ربات دیسکورد و تنظیمات اتصال",
-        "enable": "فعال‌سازی ربات دیسکورد",
-        "enableDescription": "فعال یا غیرفعال کردن عملکرد ربات دیسکورد برای سیستم شما",
+        "description": "پیکربندی اولیه ربات Discord و تنظیمات اتصال",
+        "enable": "فعال‌سازی ربات Discord",
+        "enableDescription": "فعال یا غیرفعال کردن عملکرد ربات Discord برای سیستم شما",
         "token": "توکن ربات",
-        "tokenPlaceholder": "توکن ربات دیسکورد خود را وارد کنید",
+        "tokenPlaceholder": "توکن ربات Discord خود را وارد کنید",
         "tokenDescription": "توکن ربات که از Discord Developer Portal دریافت شده",
         "proxyUrl": "آدرس پروکسی",
         "proxyUrlPlaceholder": "socks5://proxy.example.com:1080",
@@ -200,32 +200,32 @@
       }
     },
     "webhook": {
-      "title": "وبهوک",
-      "description": "پیکربندی اعلان‌های وبهوک و تنظیمات endpoint برای سیستم شما",
-      "loadError": "بارگذاری تنظیمات وبهوک ناموفق بود. لطفاً دوباره تلاش کنید.",
-      "saveSuccess": "تنظیمات وبهوک با موفقیت ذخیره شد",
-      "saveFailed": "ذخیره تنظیمات وبهوک ناموفق بود",
-      "cancelSuccess": "تغییرات لغو شد و تنظیمات اصلی وبهوک بازیابی شد",
+      "title": "Webhook",
+      "description": "پیکربندی اعلان‌های webhook و تنظیمات endpoint برای سیستم شما",
+      "loadError": "بارگذاری تنظیمات webhook ناموفق بود. لطفاً دوباره تلاش کنید.",
+      "saveSuccess": "تنظیمات webhook با موفقیت ذخیره شد",
+      "saveFailed": "ذخیره تنظیمات webhook ناموفق بود",
+      "cancelSuccess": "تغییرات لغو شد و تنظیمات اصلی webhook بازیابی شد",
       "general": {
         "title": "تنظیمات عمومی",
         "description": "پیکربندی اولیه وبهوک و تنظیمات اتصال",
-        "enable": "فعال‌سازی وبهوک‌ها",
-        "enableDescription": "فعال یا غیرفعال کردن اعلان‌های وبهوک برای سیستم شما",
+        "enable": "فعال‌سازی webhook‌ها",
+        "enableDescription": "فعال یا غیرفعال کردن اعلان‌های webhook برای سیستم شما",
         "timeout": "زمان انقضا (ثانیه)",
         "timeoutDescription": "زمان انتظار درخواست برای فراخوانی وبهوک (۱-۳۰۰ ثانیه)",
         "recurrent": "تعداد تلاش مجدد",
-        "recurrentDescription": "تعداد تلاش‌های مجدد برای وبهوک‌های ناموفق (۱-۲۴)",
+        "recurrentDescription": "تعداد تلاش‌های مجدد برای webhook‌های ناموفق (۱-۲۴)",
         "proxyUrl": "آدرس پروکسی",
         "proxyUrlPlaceholder": "http://proxy.example.com:8080",
-        "proxyUrlDescription": "آدرس پروکسی برای درخواست‌های وبهوک (اختیاری)"
+        "proxyUrlDescription": "آدرس پروکسی برای درخواست‌های webhook (اختیاری)"
       },
       "webhooks": {
-        "title": "نقاط پایانی وبهوک",
-        "description": "پیکربندی آدرس‌های وبهوک و احراز هویت",
-        "add": "افزودن وبهوک",
-        "addFirst": "افزودن اولین وبهوک",
-        "webhook": "وبهوک",
-        "empty": "هیچ وبهوکی پیکربندی نشده. اولین نقطه پایانی وبهوک خود را اضافه کنید.",
+        "title": "نقاط پایانی webhook",
+        "description": "پیکربندی آدرس‌های webhook و احراز هویت",
+        "add": "افزودن webhook",
+        "addFirst": "افزودن اولین webhook",
+        "webhook": "webhook",
+        "empty": "هیچ webhook‌ای پیکربندی نشده. اولین نقطه پایانی webhook خود را اضافه کنید.",
         "name": "نام",
         "namePlaceholder": "وبهوک من",
         "url": "آدرس",
@@ -319,8 +319,8 @@
         "description": "پر کردن خودکار فیلد جریان برای کاربران جدید VLESS"
       },
       "defaultMethod": {
-        "title": "روش پیش‌فرض شدوساکس",
-        "description": "پر کردن خودکار روش رمزنگاری برای کاربران جدید شدوساکس"
+        "title": "روش پیش‌فرض Shadowsocks",
+        "description": "پر کردن خودکار روش رمزنگاری برای کاربران جدید Shadowsocks"
       },
       "errorLoadingSettings": "خطا در بارگذاری تنظیمات"
     }
@@ -344,7 +344,7 @@
   "by": "توسط",
   "ip": "آی‌پی",
   "admin": "مدیر",
-  "sudo": "کاربر ریشه (سوپردار)",
+  "sudo": "sudo",
   "save": "ذخیره",
   "test": "تست",
   "testing": "در حال تست",
@@ -357,7 +357,7 @@
     "deleteAdmin": "حذف مدیر",
     "username": "نام کاربری",
     "password": "رمز عبور",
-    "isSudo": "مدیر ارشد",
+    "isSudo": "sudo",
     "createdAt": "تاریخ ایجاد",
     "actions": "عملیات",
     "createSuccess": "مدیر «{{name}}» با موفقیت ایجاد شد",
@@ -368,7 +368,7 @@
     "deleteFailed": "حذف مدیر {{name}} ناموفق بود",
     "enterUsername": "نام کاربری را وارد کنید",
     "enterPassword": "رمز عبور را وارد کنید",
-    "sudo": "دسترسی مدیر ارشد",
+    "sudo": "دسترسی sudo",
     "edit": "ذخیره تغییرات",
     "create": "ایجاد مدیر",
     "status": "وضعیت",
@@ -918,10 +918,10 @@
   "userDialog.warningNoProtocol": "لطفا حداقل یک پروتکل انتخاب کنید",
   "userDialog.weeks": "هفته‌ها",
   "userDialog.proxySettingsAccordion": "تنظیمات پروکسی",
-  "userDialog.proxySettings.vmess": "وی مس (VMess)",
-  "userDialog.proxySettings.vless": "وی لس (VLESS)",
-  "userDialog.proxySettings.trojan": "تروجان (Trojan)",
-  "userDialog.proxySettings.shadowsocks": "شدو ساکس (Shadowsocks)",
+  "userDialog.proxySettings.vmess": "VMess",
+  "userDialog.proxySettings.vless": "VLESS",
+  "userDialog.proxySettings.trojan": "Trojan",
+  "userDialog.proxySettings.shadowsocks": "Shadowsocks",
   "userDialog.proxySettings.id": "شناسه (ID)",
   "userDialog.proxySettings.password": "رمز عبور",
   "userDialog.proxySettings.method": "روش رمزنگاری",
@@ -1181,7 +1181,7 @@
     "radiusMedium": "متوسط",
     "radiusLarge": "بزرگ"
   },
-  "coreConfigModal": {
+    "coreConfigModal": {
     "addConfig": "افزودن پیکربندی هسته",
     "createNewConfig": "ایجاد پیکربندی جدید هسته",
     "editCore": "ویرایش پیکربندی هسته",


### PR DESCRIPTION
Changes Made:
   "گیت‌هاب" → "GitHub" (line 21)
   "دیسکورد" → "Discord" (multiple locations - lines 33, 61, 62, 183-187, 190, 194, 196)
   "وبهوک" → "webhook" (multiple locations - lines 63, 203-232)
   "شدوساکس" → "Shadowsocks" (lines 322, 323)
   "کاربر ریشه (سوپردار)" → "sudo" (line 347)
   "مدیر ارشد" → "sudo" (lines 360, 371)
Protocol names standardized to English:
     "وی مس (VMess)" → "VMess" (line 921)
     "وی لس (VLESS)" → "VLESS" (line 922)
     "تروجان (Trojan)" → "Trojan" (line 923)
     "شدو ساکس (Shadowsocks)" → "Shadowsocks" (line 924)
Summary:
Standardized English branding for GitHub, Discord
Unified technical terms (webhook, protocol names) to English
Simplified admin role terminology
Improved consistency across the interface


if you find other translation problems like this comment pls🙏