### PR TITLE
fix: Handle socket.gaierror for invalid hostnames

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def check_and_modify_ip(ip_address: str) -> str:
     Raises:
         ValueError: If the provided IP address is invalid, return localhost.
     """
-    try:
+       try:
         # Attempt to resolve hostname to IP address
         resolved_ip = socket.gethostbyname(ip_address)
 
@@ -59,7 +59,7 @@ def check_and_modify_ip(ip_address: str) -> str:
         else:
             return "localhost"
 
-    except ValueError:
+    except (ValueError, socket.gaierror):
         return "localhost"
 
 

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def check_and_modify_ip(ip_address: str) -> str:
     Raises:
         ValueError: If the provided IP address is invalid, return localhost.
     """
-       try:
+    try:
         # Attempt to resolve hostname to IP address
         resolved_ip = socket.gethostbyname(ip_address)
 


### PR DESCRIPTION
This PR adds socket.gaierror handling to prevent crashes when hostname resolution fails