### PR TITLE
Hardened node health

### DIFF
--- a/app/jobs/node_checker.py
+++ b/app/jobs/node_checker.py
@@ -39,6 +39,7 @@ async def node_health_check():
             health = await asyncio.wait_for(node.get_health(), timeout=10)
         except (asyncio.TimeoutError, NodeAPIError):
             await node_operator.update_node_status(db_node.id, NodeStatus.error, err="Get health timeout")
+            return
 
         if db_node.status in (NodeStatus.connecting, NodeStatus.error) and health is Health.HEALTHY:
             await node_operator.update_node_status(db_node.id, NodeStatus.connected)

--- a/app/utils/jwt.py
+++ b/app/utils/jwt.py
@@ -84,9 +84,18 @@ async def get_subscription_payload(token: str) -> dict | None:
                 sha256((u_token + await get_secret_key()).encode("utf-8")).digest(), altchars=b"-_"
             ).decode("utf-8")[:10]
             if u_signature == u_token_resign:
-                u_username = u_token_dec_str.split(",")[0]
-                u_created_at = int(u_token_dec_str.split(",")[1])
-                return {"username": u_username, "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc)}
+                parts = u_token_dec_str.split(",")
+                if len(parts) != 2:
+                    return
+                u_username, u_created_at_str = parts
+                try:
+                    u_created_at = int(u_created_at_str)
+                except ValueError:
+                    return
+                return {
+                    "username": u_username,
+                    "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc),
+                }
             else:
                 return
     except jwt.exceptions.PyJWTError:

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -70,6 +70,7 @@ def get_public_ip():
         except httpx.RequestError:
             pass
 
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.connect(("8.8.8.8", 80))
@@ -79,7 +80,8 @@ def get_public_ip():
     except (socket.error, IndexError):
         pass
     finally:
-        sock.close()
+        if sock:
+            sock.close()
 
     return "127.0.0.1"
 


### PR DESCRIPTION
exceptions don’t leave health undefined; the handler now exits early after logging the timeout/error to keep subsequent checks running 