### PR TITLE
Fix/sqlalchemy notin cleanup

### DIFF
--- a/app/db/crud/host.py
+++ b/app/db/crud/host.py
@@ -44,7 +44,7 @@ async def get_inbounds_not_in_tags(db: AsyncSession, excluded_tags: List[str]) -
     Returns:
         List of ProxyInbound objects not matching any tag in the list
     """
-    stmt = select(ProxyInbound).where(ProxyInbound.tag.not_in(excluded_tags))
+    stmt = select(ProxyInbound).where(ProxyInbound.tag.notin_(excluded_tags))
     result = await db.execute(stmt)
     return result.scalars().all()
 

--- a/app/jobs/cleanup_subscription_updates.py
+++ b/app/jobs/cleanup_subscription_updates.py
@@ -44,7 +44,7 @@ async def cleanup_user_subscription_updates():
                     # Delete records not in keep list
                     result = await db.execute(
                         delete(UserSubscriptionUpdate).where(
-                            UserSubscriptionUpdate.user_id == user_id, UserSubscriptionUpdate.id.not_in(keep_ids)
+                            UserSubscriptionUpdate.user_id == user_id, UserSubscriptionUpdate.id.notin_(keep_ids)
                         )
                     )
                     total_deleted += result.rowcount
@@ -63,7 +63,7 @@ async def cleanup_user_subscription_updates():
 
             result = await db.execute(
                 delete(UserSubscriptionUpdate).where(
-                    UserSubscriptionUpdate.user_id.in_(user_ids), UserSubscriptionUpdate.id.not_in(keep_subquery)
+                    UserSubscriptionUpdate.user_id.in_(user_ids), UserSubscriptionUpdate.id.notin_(keep_subquery)
                 )
             )
             logger.info(f"Cleaned up {result.rowcount} old subscription updates")

--- a/app/utils/jwt.py
+++ b/app/utils/jwt.py
@@ -84,9 +84,18 @@ async def get_subscription_payload(token: str) -> dict | None:
                 sha256((u_token + await get_secret_key()).encode("utf-8")).digest(), altchars=b"-_"
             ).decode("utf-8")[:10]
             if u_signature == u_token_resign:
-                u_username = u_token_dec_str.split(",")[0]
-                u_created_at = int(u_token_dec_str.split(",")[1])
-                return {"username": u_username, "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc)}
+                parts = u_token_dec_str.split(",")
+                if len(parts) != 2:
+                    return
+                u_username, u_created_at_str = parts
+                try:
+                    u_created_at = int(u_created_at_str)
+                except ValueError:
+                    return
+                return {
+                    "username": u_username,
+                    "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc),
+                }
             else:
                 return
     except jwt.exceptions.PyJWTError:

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -70,6 +70,7 @@ def get_public_ip():
         except httpx.RequestError:
             pass
 
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.connect(("8.8.8.8", 80))
@@ -79,7 +80,8 @@ def get_public_ip():
     except (socket.error, IndexError):
         pass
     finally:
-        sock.close()
+        if sock:
+            sock.close()
 
     return "127.0.0.1"
 


### PR DESCRIPTION
Updated SQL cleanup queries to use SQLAlchemy’s supported notin_ operators, preventing AttributeErrors that previously stopped subscription/pruning jobs from deleting stale records