### PR TITLE
Fix/node removal api

### DIFF
--- a/app/node/__init__.py
+++ b/app/node/__init__.py
@@ -103,7 +103,7 @@ class NodeManager:
         proto_user = serialize_user_for_node(user.id, user.username, user.proxy_settings.dict())
 
         async with self._lock.reader_lock:
-            remove_tasks = [node.update_user(proto_user) for node in self._nodes.values()]
+            remove_tasks = [node.remove_user(proto_user) for node in self._nodes.values()]
             await asyncio.gather(*remove_tasks, return_exceptions=True)
 
 

--- a/app/utils/jwt.py
+++ b/app/utils/jwt.py
@@ -84,9 +84,18 @@ async def get_subscription_payload(token: str) -> dict | None:
                 sha256((u_token + await get_secret_key()).encode("utf-8")).digest(), altchars=b"-_"
             ).decode("utf-8")[:10]
             if u_signature == u_token_resign:
-                u_username = u_token_dec_str.split(",")[0]
-                u_created_at = int(u_token_dec_str.split(",")[1])
-                return {"username": u_username, "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc)}
+                parts = u_token_dec_str.split(",")
+                if len(parts) != 2:
+                    return
+                u_username, u_created_at_str = parts
+                try:
+                    u_created_at = int(u_created_at_str)
+                except ValueError:
+                    return
+                return {
+                    "username": u_username,
+                    "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc),
+                }
             else:
                 return
     except jwt.exceptions.PyJWTError:

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -70,6 +70,7 @@ def get_public_ip():
         except httpx.RequestError:
             pass
 
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.connect(("8.8.8.8", 80))
@@ -79,7 +80,8 @@ def get_public_ip():
     except (socket.error, IndexError):
         pass
     finally:
-        sock.close()
+        if sock:
+            sock.close()
 
     return "127.0.0.1"
 


### PR DESCRIPTION
Switched the node removal path to call the bridge’s dedicated removal API rather than reusing the update call, so users marked for deletion are actually dropped from connected nodes