### PR TITLE
Fix admin crud row error

### DIFF
--- a/app/db/crud/admin.py
+++ b/app/db/crud/admin.py
@@ -110,7 +110,7 @@ async def get_admin_by_id(db: AsyncSession, id: int) -> Admin:
     Returns:
         Admin: The admin object.
     """
-    admin = (await db.execute(select(Admin).where(Admin.id == id))).first()
+    admin = (await db.execute(select(Admin).where(Admin.id == id))).scalar_one_or_none()
     if admin:
         await load_admin_attrs(admin)
     return admin
@@ -144,7 +144,7 @@ async def get_admin_by_discord_id(db: AsyncSession, discord_id: int) -> Admin:
     Returns:
         Admin: The admin object.
     """
-    admin = (await db.execute(select(Admin).where(Admin.discord_id == discord_id))).first()
+    admin = (await db.execute(select(Admin).where(Admin.discord_id == discord_id))).scalar_one_or_none()
     if admin:
         await load_admin_attrs(admin)
     return admin

--- a/app/utils/jwt.py
+++ b/app/utils/jwt.py
@@ -84,9 +84,18 @@ async def get_subscription_payload(token: str) -> dict | None:
                 sha256((u_token + await get_secret_key()).encode("utf-8")).digest(), altchars=b"-_"
             ).decode("utf-8")[:10]
             if u_signature == u_token_resign:
-                u_username = u_token_dec_str.split(",")[0]
-                u_created_at = int(u_token_dec_str.split(",")[1])
-                return {"username": u_username, "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc)}
+                parts = u_token_dec_str.split(",")
+                if len(parts) != 2:
+                    return
+                u_username, u_created_at_str = parts
+                try:
+                    u_created_at = int(u_created_at_str)
+                except ValueError:
+                    return
+                return {
+                    "username": u_username,
+                    "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc),
+                }
             else:
                 return
     except jwt.exceptions.PyJWTError:

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -70,6 +70,7 @@ def get_public_ip():
         except httpx.RequestError:
             pass
 
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.connect(("8.8.8.8", 80))
@@ -79,7 +80,8 @@ def get_public_ip():
     except (socket.error, IndexError):
         pass
     finally:
-        sock.close()
+        if sock:
+            sock.close()
 
     return "127.0.0.1"
 


### PR DESCRIPTION
Both get_admin_by_id and get_admin_by_discord_id were using Result.first(), which returns a plain SQLAlchemy Row object.
Passing that row into load_admin_attrs caused an AttributeError ('Row' object has no attribute 'awaitable_attrs').
This update changes those functions to return proper ORM instances, fixing the error and making the admin lookup helpers usable again