### PR TITLE
feat: پیاده‌سازی توکن اشتراک ثابت برای کاربران

### DIFF
--- a/app/db/crud/user.py
+++ b/app/db/crud/user.py
@@ -58,6 +58,25 @@ async def get_user(db: AsyncSession, username: str) -> Optional[User]:
     return user
 
 
+async def get_user_by_static_token(db: AsyncSession, static_token: str) -> User | None:
+    """
+    Retrieves a user by static token.
+
+    Args:
+        db (AsyncSession): Database session.
+        static_token (str): The static token of the user.
+
+    Returns:
+        Optional[User]: The user object if found, else None.
+    """
+    stmt = select(User).where(User.static_token == static_token)
+
+    user = (await db.execute(stmt)).unique().scalar_one_or_none()
+    if user:
+        await load_user_attrs(user)
+    return user
+
+
 async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
     """
     Retrieves a user by user ID.

--- a/app/db/migrations/versions/c1ec5e0171a3_add_static_subscription_token_to_users.py
+++ b/app/db/migrations/versions/c1ec5e0171a3_add_static_subscription_token_to_users.py
@@ -1,0 +1,30 @@
+"""add static subscription token to users
+
+Revision ID: c1ec5e0171a3
+Revises: 99076844dee6
+Create Date: 2025-11-16 01:26:18.914275
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c1ec5e0171a3'
+down_revision = '99076844dee6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('static_token', sa.String(length=128), nullable=True))
+        batch_op.add_column(sa.Column('use_static_token', sa.Boolean(), server_default=sa.text('0'), nullable=False))
+        batch_op.create_unique_constraint('uq_users_static_token', ['static_token'])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_users_static_token', type_='unique')
+        batch_op.drop_column('use_static_token')
+        batch_op.drop_column('static_token')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -159,6 +159,8 @@ class User(Base):
     auto_delete_in_days: Mapped[Optional[int]] = mapped_column(default=None)
     edit_at: Mapped[Optional[dt]] = mapped_column(DateTime(timezone=True), default=None)
     last_status_change: Mapped[Optional[dt]] = mapped_column(DateTime(timezone=True), default=None)
+    static_token: Mapped[Optional[str]] = mapped_column(String(128), unique=True, default=None)
+    use_static_token: Mapped[bool] = mapped_column(server_default=text("0"), default=False)
 
     @hybrid_property
     def expire(self) -> Optional[dt]:

--- a/app/exception.py
+++ b/app/exception.py
@@ -1,0 +1,6 @@
+from fastapi import HTTPException
+
+
+class UserNotFoundException(HTTPException):
+    def __init__(self):
+        super().__init__(status_code=404, detail="User not found")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -113,6 +113,8 @@ class UserNotificationResponse(User):
 class UserResponse(UserNotificationResponse):
     admin: AdminBase | None = Field(default=None)
     group_names: list[str] | None = Field(default=None, exclude=True)
+    static_token: str | None = Field(default=None)
+    use_static_token: bool = Field(default=False)
 
 
 class SubscriptionUserResponse(UserResponse):
@@ -181,7 +183,11 @@ class BulkUser(BaseModel):
     group_ids: set[int] = Field(default_factory=set)
     admins: set[int] = Field(default_factory=set)
     users: set[int] = Field(default_factory=set)
-    status: set[UserStatus] = Field(default_factory=set)
+
+
+class StaticToken(BaseModel):
+    use_static_token: bool
+    regenerate: bool = False
 
 
 class BulkUsersProxy(BaseModel):

--- a/app/operation/__init__.py
+++ b/app/operation/__init__.py
@@ -15,7 +15,7 @@ from app.db.crud import (
     get_user_template,
 )
 from app.db.crud.admin import get_admin_by_id
-from app.db.crud.user import get_user_by_id
+from app.db.crud.user import get_user_by_id, get_user_by_static_token
 from app.db.models import Admin as DBAdmin, CoreConfig, Group, Node, ProxyHost, User, UserTemplate
 from app.models.admin import AdminDetails
 from app.models.group import BulkGroup
@@ -81,6 +81,10 @@ class BaseOperation:
         return db_host
 
     async def get_validated_sub(self, db: AsyncSession, token: str) -> User:
+        db_user = await get_user_by_static_token(db, token)
+        if db_user and db_user.use_static_token:
+            return db_user
+
         sub = await get_subscription_payload(token)
         if not sub:
             await self.raise_error(message="Not Found", code=404)

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -18,6 +18,7 @@ from app.models.user import (
     UsersResponse,
     UserSubscriptionUpdateChart,
     UserSubscriptionUpdateList,
+    StaticToken,
 )
 from app.operation import OperatorType
 from app.operation.node import NodeOperation
@@ -372,3 +373,23 @@ async def bulk_modify_users_proxy_settings(
     _: AdminDetails = Depends(check_sudo_admin),
 ):
     return await user_operator.bulk_modify_proxy_settings(db, bulk_model)
+
+
+@router.put(
+    "/{username}/static_token",
+    response_model=UserResponse,
+    responses={400: responses._400, 403: responses._403, 404: responses._404},
+)
+async def manage_static_token(
+    username: str,
+    in_data: StaticToken,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    """Manage user static token"""
+    return await user_operator.manage_static_token(
+        db,
+        username=username,
+        in_data=in_data,
+        admin=admin,
+    )

--- a/dashboard/src/pages/_dashboard.users.tsx
+++ b/dashboard/src/pages/_dashboard.users.tsx
@@ -75,6 +75,8 @@ export const userCreateSchema = z.object({
   auto_delete_in_days: z.number().optional(),
   next_plan: nextPlanModelSchema.optional(),
   template_id: z.number().optional(),
+  static_token: z.string().optional(),
+  use_static_token: z.boolean().optional(),
 })
 
 export const userEditSchema = z.object({
@@ -103,6 +105,8 @@ export const userEditSchema = z.object({
   auto_delete_in_days: z.number().optional(),
   next_plan: nextPlanModelSchema.optional(),
   template_id: z.number().optional(),
+  static_token: z.string().optional(),
+  use_static_token: z.boolean().optional(),
 })
 
 export type UseEditFormValues = z.infer<typeof userEditSchema>

--- a/dashboard/src/service/api/index.ts
+++ b/dashboard/src/service/api/index.ts
@@ -614,6 +614,8 @@ export interface UserResponse {
   online_at?: UserResponseOnlineAt
   subscription_url?: string
   admin?: UserResponseAdmin
+  use_static_token?: boolean
+  static_token?: string | null
 }
 
 export interface UserNotificationEnable {
@@ -2176,6 +2178,55 @@ export const useAdminToken = <TData = Awaited<ReturnType<typeof adminToken>>, TE
   mutation?: UseMutationOptions<TData, TError, { data: BodyType<BodyAdminTokenApiAdminTokenPost> }, TContext>
 }): UseMutationResult<TData, TError, { data: BodyType<BodyAdminTokenApiAdminTokenPost> }, TContext> => {
   const mutationOptions = getAdminTokenMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+export interface StaticToken {
+  use_static_token: boolean
+  static_token?: string | null
+}
+
+export const manageStaticToken = (username: string, staticToken: BodyType<StaticToken>) => {
+  return orvalFetcher<UserResponse>({
+    url: `/api/user/${username}/static_token`,
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    data: staticToken,
+  })
+}
+
+export const getManageStaticTokenMutationOptions = <
+  TData = Awaited<ReturnType<typeof manageStaticToken>>,
+  TError = ErrorType<HTTPException | Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<StaticToken> }, TContext>
+}) => {
+  const mutationKey = ['manageStaticToken']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof manageStaticToken>>, { username: string; data: BodyType<StaticToken> }> = props => {
+    const { username, data } = props ?? {}
+
+    return manageStaticToken(username, data)
+  }
+
+  return { mutationFn, ...mutationOptions }
+}
+
+export const useManageStaticToken = <
+  TData = Awaited<ReturnType<typeof manageStaticToken>>,
+  TError = ErrorType<HTTPException | Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<StaticToken> }, TContext>
+}): UseMutationResult<TData, TError, { username: string; data: BodyType<StaticToken> }, TContext> => {
+  const mutationOptions = getManageStaticTokenMutationOptions(options)
 
   return useMutation(mutationOptions)
 }


### PR DESCRIPTION
این کامیت یک ویژگی جدید برای استفاده از توکن اشتراک ثابت به جای توکن‌های پویا معرفی می‌کند. این ویژگی به کاربران اجازه می‌دهد تا یک توکن ثابت و قابل پیش‌بینی برای لینک اشتراک خود داشته باشند.

تغییرات شامل:
- افزودن فیلدهای `static_token` و `use_static_token` به مدل کاربر و پایگاه داده.
- پیاده‌سازی یک مسیر API جدید (`PUT /api/user/{username}/static_token`) برای مدیریت توکن ثابت (فعال‌سازی، غیرفعال‌سازی و تولید مجدد).
- به‌روزرسانی منطق اعتبارسنجی اشتراک برای پشتیبانی از توکن ثابت.
- افزودن یک بخش جدید در مودال ویرایش کاربر در فرانت‌اند که شامل یک سوئیچ برای فعال‌سازی توکن ثابت و یک دکمه برای تولید مجدد آن است.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static token authentication capability added for users
  * New dashboard interface for static token management featuring toggle control and regeneration
  * Static token values now displayed in user profile section when enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->