### PR TITLE
fix[admin]: make is_sudo optional on AdminModify

### DIFF
--- a/app/models/admin.py
+++ b/app/models/admin.py
@@ -66,7 +66,7 @@ class AdminDetails(AdminContactInfo):
 
 class AdminModify(BaseModel):
     password: str | None = None
-    is_sudo: bool
+    is_sudo: bool | None = None
     telegram_id: int | None = None
     discord_webhook: str | None = None
     discord_id: int | None = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin modifications now allow the sudo flag to be optional during updates, eliminating the requirement to always specify this parameter and providing greater flexibility when managing administrator settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->