### PR TITLE
feat[admins]: add get_admin endpoint

### DIFF
--- a/app/operation/admin.py
+++ b/app/operation/admin.py
@@ -174,3 +174,8 @@ class AdminOperation(BaseOperation):
         asyncio.create_task(notification.admin_usage_reset(reseted_admin, admin.username))
 
         return reseted_admin
+
+    async def get_admin(self, db: AsyncSession, username: str) -> AdminDetails:
+        """Get a specific admin by username."""
+        db_admin = await self.get_validated_admin(db, username=username)
+        return AdminDetails.model_validate(db_admin)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -119,6 +119,16 @@ def get_current_admin(admin: AdminDetails = Depends(get_current)):
     return admin
 
 
+@router.get("/{username}", response_model=AdminDetails, responses={404: responses._404})
+async def get_admin(
+    username: str,
+    db: AsyncSession = Depends(get_db),
+    _: AdminDetails = Depends(check_sudo_admin),
+):
+    """Retrieve a specific admin by username."""
+    return await admin_operator.get_admin(db, username=username)
+
+
 @router.get("s", response_model=AdminsResponse)
 async def get_admins(
     username: str | None = None,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve detailed information about specific admins by username. This endpoint is restricted to admin-level users and includes proper request validation. Returns a 404 error when the requested admin cannot be found. Administrators can now look up individual admin profiles within the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->