### PR TITLE
feat: Add permission manager scaffold with sudo bypass hooks

### DIFF
--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from app.models.admin import AdminDetails
+
+
+@dataclass
+class PermissionCheckResult:
+    """Represents the result of a permission check."""
+
+    allowed: bool
+    reason: str | None = None
+
+
+class PermissionManager:
+    """Central place to allow admin permissions
+
+    Currently allows everything you can add real permissions later
+    """
+
+    def __init__(self, operator_type: int | None = None):
+        self.operator_type = operator_type
+
+    async def check(
+        self,
+        action: str,
+        *,
+        admin: AdminDetails | None = None,
+        context: Mapping[str, Any] | None = None,
+    ) -> PermissionCheckResult:
+        """Return an allow-all result; hook point for future enforcement"""
+        if admin and admin.is_sudo:
+            return PermissionCheckResult(allowed=True)
+
+        # Example placeholder: enforce traffic limits for non-sudo admins
+        # if action == "user.create":
+        #     proposed_mb = (context or {}).get("data_limit_mb", 0)
+        #     current_mb = (context or {}).get("current_usage_mb", 0)
+        #     quota_mb = (context or {}).get("quota_mb")
+        #     if quota_mb is not None and current_mb + proposed_mb > quota_mb:
+        #         return PermissionCheckResult(allowed=False, reason="Traffic quota exceeded")
+
+        return PermissionCheckResult(allowed=True)

--- a/app/operation/__init__.py
+++ b/app/operation/__init__.py
@@ -1,5 +1,6 @@
 from datetime import datetime as dt, timedelta as td, timezone as tz
 from enum import IntEnum
+from typing import TYPE_CHECKING
 
 from fastapi import HTTPException
 
@@ -23,6 +24,9 @@ from app.models.user import UserCreate, UserModify
 from app.utils.helpers import fix_datetime_timezone
 from app.utils.jwt import get_subscription_payload
 
+if TYPE_CHECKING:
+    from app.core.permissions import PermissionCheckResult
+
 
 class OperatorType(IntEnum):
     SYSTEM = 0
@@ -36,6 +40,11 @@ class OperatorType(IntEnum):
 class BaseOperation:
     def __init__(self, operator_type: OperatorType):
         self.operator_type = operator_type
+
+    async def ensure_allowed(self, check: "PermissionCheckResult"):
+        """Raise an error if a permission check failed."""
+        if not check.allowed:
+            await self.raise_error(message=check.reason or "You're not allowed", code=403)
 
     async def raise_error(self, message: str, code: int, db: AsyncSession | None = None):
         """Raise an error based on the operator type."""


### PR DESCRIPTION
added a central PermissionManager scaffold with sudo bypass and placeholder limit checks, and routed admin/user operations through it using allow-all results so behavior stays unchanged while providing a single enforcement hook for future rules