### PR TITLE
feat(dashboard): add copy subscription link button to subscription modal

### DIFF
--- a/dashboard/src/components/dialogs/subscription-modal.tsx
+++ b/dashboard/src/components/dialogs/subscription-modal.tsx
@@ -192,6 +192,10 @@ const SubscriptionModal: FC<SubscriptionModalProps> = memo(({ subscribeUrl, user
             {/* Subscription QR Code Section */}
             <div className="flex w-full items-center justify-between">
               <span className="text-sm font-medium">{t('subscriptionModal.subscriptionLink', { defaultValue: 'Subscription Link' })}</span>
+              <Button variant="outline" size="sm" onClick={() => handleCopyConfig(sublink)} className="h-8">
+                {copiedConfig === sublink ? <Check className={cn('h-4 w-4', isRTL ? 'ml-2' : 'mr-2')} /> : <Copy className={cn('h-4 w-4', isRTL ? 'ml-2' : 'mr-2')} />}
+                {t('subscriptionModal.copyLink', { defaultValue: 'Copy Link' })}
+              </Button>
             </div>
             <div className="flex flex-col items-center gap-3 rounded-lg border p-4">
               <div dir="ltr" className="flex max-w-[200px] items-center justify-center overflow-hidden">


### PR DESCRIPTION
## Summary
Added a "Copy Link" button to the subscription modal header section.

## Changes
- Added copy button next to "Subscription Link" title in subscription modal
- Button copies the subscription URL to clipboard
- Shows checkmark icon with visual feedback when copied