### PR TITLE
fix: Include SpiderX value from Xray config in host API responses

### DIFF
--- a/app/models/host.py
+++ b/app/models/host.py
@@ -238,7 +238,7 @@ class BaseHost(BaseModel):
     priority: int
     status: set[UserStatus] | None = Field(default_factory=set)
     ech_config_list: str | None = Field(default=None)
-    pinnedPeerCertSha256:str| None = Field(default=None)
+    reality_spx: str | None = Field(default=None)
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/routers/host.py
+++ b/app/routers/host.py
@@ -18,7 +18,9 @@ async def get_host(host_id: int, db: AsyncSession = Depends(get_db), _: AdminDet
     """
     get host by **id**
     """
-    return await host_operator.get_validated_host(db=db, host_id=host_id)
+    db_host = await host_operator.get_validated_host(db=db, host_id=host_id)
+    host = BaseHost.model_validate(db_host)
+    return await host_operator._merge_inbound_config(host)
 
 
 @router.get("s", response_model=list[BaseHost])


### PR DESCRIPTION
Added a reality_spx field to the BaseHost model to include the SpiderX value in responses
Updated host operations to merge inbound config values when returning hosts If a host has an inbound_tag we fetch the inbound config and pull the spx value into reality_spx
Applied this merging in get_hosts(), create_host(), modify_host(), and the single host GET endpoint