### PR TITLE
install_service.sh: run main script inside uv .venv environment

### DIFF
--- a/install_service.sh
+++ b/install_service.sh
@@ -14,7 +14,7 @@ Documentation=$SERVICE_DOCUMENTATION
 After=network.target nss-lookup.target
 
 [Service]
-ExecStart=/usr/bin/env python3 $MAIN_PY_PATH
+ExecStart=$PWD/.venv/bin/python3 $MAIN_PY_PATH
 Restart=on-failure
 WorkingDirectory=$PWD
 


### PR DESCRIPTION
### Expected behaviour:
After building PasarGuard Panel from source code using `make` commands and running `install_service.sh` script, the service would be successfully installed and started.

### Actual behaviour:
During the service start, python cannot find any dependent packages, as `ExecStart=/usr/bin/env python3` resolved to the global environment, not the environment installed by `uv` (checked on Ubuntu 24.04.3 LTS).

### Fix:
`ExecStart` was changed from `/usr/bin/env python3` to `$PWD/.venv/bin/python3`, so the main script would be called directly in the virtual environment installed by `uv` during previous `make requirements` command. 