### PR TITLE
feat(hosts): add per-host client template overrides

### DIFF
--- a/app/core/hosts.py
+++ b/app/core/hosts.py
@@ -269,6 +269,7 @@ async def _prepare_subscription_inbound_data(
     return SubscriptionInboundData(
         remark=host.remark,
         inbound_tag=host.inbound_tag,
+        client_template_ids=host.client_template_ids,
         protocol=protocol,
         address=address_list,
         port=port_list,  # Store the LIST for random selection!

--- a/app/db/crud/client_template.py
+++ b/app/db/crud/client_template.py
@@ -30,6 +30,10 @@ ClientTemplateSortingOptionsSimple = Enum(
 
 
 async def get_client_template_values(db: AsyncSession) -> dict[str, str]:
+    return (await get_client_template_catalog(db))["defaults"]
+
+
+async def get_client_template_catalog(db: AsyncSession) -> dict[str, dict]:
     try:
         rows = (
             await db.execute(
@@ -49,6 +53,7 @@ async def get_client_template_values(db: AsyncSession) -> dict[str, str]:
         by_type[row.template_type].append((row.id, row.content, row.is_default))
 
     values: dict[str, str] = {}
+    by_id: dict[int, dict[str, str | int]] = {}
     for template_type, legacy_key in TEMPLATE_TYPE_TO_LEGACY_KEY.items():
         type_rows = by_type.get(template_type.value, [])
         if not type_rows:
@@ -66,7 +71,20 @@ async def get_client_template_values(db: AsyncSession) -> dict[str, str]:
         if selected_content:
             values[legacy_key] = selected_content
 
-    return values
+    for row in rows:
+        try:
+            template_type = ClientTemplateType(row.template_type)
+        except ValueError:
+            continue
+
+        by_id[row.id] = {
+            "id": row.id,
+            "template_type": row.template_type,
+            "legacy_key": TEMPLATE_TYPE_TO_LEGACY_KEY[template_type],
+            "content": row.content,
+        }
+
+    return {"defaults": values, "by_id": by_id}
 
 
 async def get_client_template_by_id(db: AsyncSession, template_id: int) -> ClientTemplate | None:

--- a/app/db/migrations/versions/6c4e9c0df0b1_add_client_template_overrides_to_hosts.py
+++ b/app/db/migrations/versions/6c4e9c0df0b1_add_client_template_overrides_to_hosts.py
@@ -1,0 +1,26 @@
+"""add client template overrides to hosts
+
+Revision ID: 6c4e9c0df0b1
+Revises: 145c22ab174f
+Create Date: 2026-04-02 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "6c4e9c0df0b1"
+down_revision = "145c22ab174f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.add_column(sa.Column("client_template_ids", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.drop_column("client_template_ids")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -457,6 +457,7 @@ class ProxyHost(Base):
         String(256), ForeignKey("inbounds.tag", ondelete="SET NULL", onupdate="CASCADE"), nullable=True, init=False
     )
     inbound: Mapped[Optional["ProxyInbound"]] = relationship(back_populates="hosts", init=False)
+    client_template_ids: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON(none_as_null=True), default=None)
     security: Mapped[ProxyHostSecurity] = mapped_column(
         SQLEnum(ProxyHostSecurity),
         unique=False,

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -220,11 +220,20 @@ class FormatVariables(dict):
         return key.join("{}")
 
 
+class HostClientTemplateIds(BaseModel):
+    clash_subscription: int | None = Field(default=None)
+    xray_subscription: int | None = Field(default=None)
+    singbox_subscription: int | None = Field(default=None)
+    user_agent: int | None = Field(default=None)
+    grpc_user_agent: int | None = Field(default=None)
+
+
 class BaseHost(BaseModel):
     id: int | None = Field(default=None)
     remark: str
     address: set[str] = Field(default_factory=set)
     inbound_tag: str | None = Field(default=None)
+    client_template_ids: HostClientTemplateIds | None = Field(default=None)
     port: int | None = Field(default=None)
     sni: set[str] | None = Field(default_factory=set)
     host: set[str] | None = Field(default_factory=set)

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, computed_field
 
+from app.models.host import HostClientTemplateIds
+
 
 class TLSConfig(BaseModel):
     """TLS configuration - only TLS-related fields"""
@@ -210,6 +212,7 @@ class SubscriptionInboundData(BaseModel):
     # Basic info
     remark: str
     inbound_tag: str
+    client_template_ids: HostClientTemplateIds | None = Field(default=None)
     protocol: str
     address: list[str] | str = Field(default_factory=list)
     port: list[int] | int = Field(default_factory=list)

--- a/app/operation/host.py
+++ b/app/operation/host.py
@@ -2,6 +2,7 @@ import asyncio
 
 from app.db import AsyncSession
 from app.db.models import ProxyHost
+from app.models.client_template import ClientTemplateType
 from app.models.host import CreateHost, BaseHost
 from app.models.admin import AdminDetails
 from app.operation import BaseOperation
@@ -22,6 +23,24 @@ logger = get_logger("host-operation")
 
 
 class HostOperation(BaseOperation):
+    async def validate_client_template_ids(self, db: AsyncSession, host: CreateHost) -> None:
+        if not host.client_template_ids:
+            return
+
+        for template_type, template_id in host.client_template_ids.model_dump().items():
+            if template_id is None:
+                continue
+
+            db_template = await self.get_validated_client_template(db, template_id)
+            if db_template.template_type != template_type:
+                await self.raise_error(
+                    message=(
+                        f'Client template "{template_id}" must be of type "{ClientTemplateType(template_type).value}"'
+                    ),
+                    code=400,
+                    db=db,
+                )
+
     async def get_hosts(self, db: AsyncSession, offset: int = 0, limit: int = 0) -> list[BaseHost]:
         return await get_hosts(db=db, offset=offset, limit=limit)
 
@@ -45,6 +64,7 @@ class HostOperation(BaseOperation):
 
     async def create_host(self, db: AsyncSession, new_host: CreateHost, admin: AdminDetails) -> BaseHost:
         await self.validate_ds_host(db, new_host)
+        await self.validate_client_template_ids(db, new_host)
 
         await self.check_inbound_tags([new_host.inbound_tag])
 
@@ -63,6 +83,7 @@ class HostOperation(BaseOperation):
         self, db: AsyncSession, host_id: int, modified_host: CreateHost, admin: AdminDetails
     ) -> BaseHost:
         await self.validate_ds_host(db, modified_host, host_id)
+        await self.validate_client_template_ids(db, modified_host)
 
         if modified_host.inbound_tag:
             await self.check_inbound_tags([modified_host.inbound_tag])
@@ -96,6 +117,7 @@ class HostOperation(BaseOperation):
     ) -> list[BaseHost]:
         for host in modified_hosts:
             await self.validate_ds_host(db, host, host.id)
+            await self.validate_client_template_ids(db, host)
 
             old_host: ProxyHost | None = None
             if host.id is not None:

--- a/app/subscription/client_templates.py
+++ b/app/subscription/client_templates.py
@@ -1,13 +1,13 @@
 from aiocache import cached
 
 from app.db import GetDB
-from app.db.crud.client_template import get_client_template_values
+from app.db.crud.client_template import get_client_template_catalog
 
 
 @cached()
-async def subscription_client_templates() -> dict[str, str]:
+async def subscription_client_templates() -> dict[str, dict]:
     async with GetDB() as db:
-        return await get_client_template_values(db)
+        return await get_client_template_catalog(db)
 
 
 async def refresh_client_templates_cache() -> None:

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -34,6 +34,84 @@ STATUS_EMOJIS = {
     "on_hold": "🔌",
 }
 
+CONFIG_FORMAT_TEMPLATE_KEYS = {
+    "clash": "clash_subscription",
+    "clash_meta": "clash_subscription",
+    "sing_box": "singbox_subscription",
+    "xray": "xray_subscription",
+}
+
+TEMPLATE_TYPE_TO_LEGACY_KEY = {
+    "clash_subscription": "CLASH_SUBSCRIPTION_TEMPLATE",
+    "xray_subscription": "XRAY_SUBSCRIPTION_TEMPLATE",
+    "singbox_subscription": "SINGBOX_SUBSCRIPTION_TEMPLATE",
+    "user_agent": "USER_AGENT_TEMPLATE",
+    "grpc_user_agent": "GRPC_USER_AGENT_TEMPLATE",
+}
+
+
+def _template_keys_for_format(config_format: str) -> list[str]:
+    template_types = ["user_agent", "grpc_user_agent"]
+    main_template_type = CONFIG_FORMAT_TEMPLATE_KEYS.get(config_format)
+    if main_template_type:
+        template_types.append(main_template_type)
+    return template_types
+
+
+def _resolve_template_content_for_hosts(
+    template_type: str,
+    defaults: dict[str, str],
+    catalog_by_id: dict[int, dict[str, str | int]],
+    hosts: list[SubscriptionInboundData],
+) -> str:
+    legacy_key = TEMPLATE_TYPE_TO_LEGACY_KEY[template_type]
+    default_content = defaults[legacy_key]
+    if not hosts:
+        return default_content
+
+    selected_ids: set[int] = set()
+    for host in hosts:
+        template_ids = host.client_template_ids.model_dump() if host.client_template_ids else {}
+        selected_template_id = template_ids.get(template_type)
+        if selected_template_id is None:
+            return default_content
+
+        selected = catalog_by_id.get(selected_template_id)
+        if not selected or selected.get("template_type") != template_type:
+            return default_content
+
+        selected_ids.add(selected_template_id)
+        if len(selected_ids) > 1:
+            return default_content
+
+    if not selected_ids:
+        return default_content
+
+    selected_template = catalog_by_id[next(iter(selected_ids))]
+    return str(selected_template["content"])
+
+
+def _resolve_request_client_templates(
+    config_format: str,
+    client_template_catalog: dict[str, dict],
+    hosts: list[SubscriptionInboundData],
+) -> dict[str, str]:
+    defaults = client_template_catalog["defaults"]
+    catalog_by_id = client_template_catalog["by_id"]
+    resolved_templates = dict(defaults)
+
+    for template_type in _template_keys_for_format(config_format):
+        legacy_key = TEMPLATE_TYPE_TO_LEGACY_KEY[template_type]
+        resolved_templates[legacy_key] = _resolve_template_content_for_hosts(
+            template_type,
+            defaults,
+            catalog_by_id,
+            hosts,
+        )
+
+    return resolved_templates
+
+
 def _build_subscription_config(
     config_format: str,
     client_templates: dict[str, str],
@@ -72,20 +150,24 @@ async def generate_subscription(
     reverse: bool = False,
     randomize_order: bool = False,
 ) -> str:
-    client_templates = await subscription_client_templates()
+    client_template_catalog = await subscription_client_templates()
+    format_variables = setup_format_variables(user)
+    hosts = await filter_hosts(list((await host_manager.get_hosts()).values()), user.status)
+    if randomize_order and len(hosts) > 1:
+        random.shuffle(hosts)
+
+    client_templates = _resolve_request_client_templates(config_format, client_template_catalog, hosts)
     conf = _build_subscription_config(config_format, client_templates)
     if conf is None:
         raise ValueError(f'Unsupported format "{config_format}"')
-
-    format_variables = setup_format_variables(user)
 
     config = await process_inbounds_and_tags(
         user,
         format_variables,
         conf,
         client_templates,
+        hosts,
         reverse,
-        randomize_order=randomize_order,
     )
 
     if as_base64:
@@ -319,13 +401,10 @@ async def process_inbounds_and_tags(
     | ClashMetaConfiguration
     | OutlineConfiguration,
     client_templates: dict[str, str],
+    hosts: list[SubscriptionInboundData],
     reverse=False,
-    randomize_order: bool = False,
 ) -> list | str:
     proxy_settings = user.proxy_settings.dict()
-    hosts = await filter_hosts(list((await host_manager.get_hosts()).values()), user.status)
-    if randomize_order and len(hosts) > 1:
-        random.shuffle(hosts)
     for host_data in hosts:
         result = await process_host(host_data, format_variables, user.inbounds, proxy_settings)
         if not result:

--- a/dashboard/public/statics/locales/en.json
+++ b/dashboard/public/statics/locales/en.json
@@ -1128,6 +1128,25 @@
     "nextPlanDataLimit": "Data Limit (GB)",
     "nextPlanExpire": "Expire (days)",
     "nextPlanAddRemainingTraffic": "Add Remaining Traffic",
+    "clientTemplateOverrides": "Client Templates",
+    "clientTemplateOverridesDescription": "Leave fields empty to follow the normal default templates.",
+    "clearOverrides": "Clear all",
+    "useDefaultTemplate": "Default",
+    "clientTemplatePlaceholder": "Follow default template",
+    "clientTemplateTypes": {
+      "clashSubscription": "Clash / Clash Meta",
+      "xraySubscription": "Xray",
+      "singboxSubscription": "Sing-box",
+      "userAgent": "User-Agent",
+      "grpcUserAgent": "gRPC User-Agent"
+    },
+    "clientTemplateTypeDescriptions": {
+      "clashSubscription": "Override the Clash YAML template for this host.",
+      "xraySubscription": "Override the Xray JSON template for this host.",
+      "singboxSubscription": "Override the sing-box JSON template for this host.",
+      "userAgent": "Override the HTTP user-agent pool for this host.",
+      "grpcUserAgent": "Override the gRPC user-agent pool for this host."
+    },
     "routingSettings": "Routing",
     "vlessRoute": "VLESS Route",
     "vlessRoutePlaceholder": "e.g. abcd",

--- a/dashboard/public/statics/locales/fa.json
+++ b/dashboard/public/statics/locales/fa.json
@@ -994,10 +994,29 @@
       "505": "نسخه HTTP پشتیبانی نمی‌شود"
     },
     "selectReason": "انتخاب دلیل",
-    "routingSettings": "Routing",
-    "vlessRoute": "VLESS Route",
-    "vlessRoutePlaceholder": "e.g. abcd",
-    "vlessRoute.info": "Optional route value for VLESS hosts. Must be exactly 4 hexadecimal characters (0-9, a-f, A-F). Leave empty to use default routing."
+    "clientTemplateOverrides": "قالب‌های کلاینت",
+    "clientTemplateOverridesDescription": "برای استفاده از قالب‌های پیش‌فرض، این فیلدها را خالی بگذارید.",
+    "clearOverrides": "پاک کردن همه",
+    "useDefaultTemplate": "پیش‌فرض",
+    "clientTemplatePlaceholder": "استفاده از قالب پیش‌فرض",
+    "clientTemplateTypes": {
+      "clashSubscription": "Clash / Clash Meta",
+      "xraySubscription": "Xray",
+      "singboxSubscription": "Sing-box",
+      "userAgent": "User-Agent",
+      "grpcUserAgent": "gRPC User-Agent"
+    },
+    "clientTemplateTypeDescriptions": {
+      "clashSubscription": "قالب YAML کلش را فقط برای این هاست تغییر می‌دهد.",
+      "xraySubscription": "قالب JSON ایکس‌ری را فقط برای این هاست تغییر می‌دهد.",
+      "singboxSubscription": "قالب JSON سینگ‌باکس را فقط برای این هاست تغییر می‌دهد.",
+      "userAgent": "لیست User-Agent مربوط به HTTP را برای این هاست تغییر می‌دهد.",
+      "grpcUserAgent": "لیست User-Agent مربوط به gRPC را برای این هاست تغییر می‌دهد."
+    },
+    "routingSettings": "مسیریابی",
+    "vlessRoute": "مسیر VLESS",
+    "vlessRoutePlaceholder": "مثلاً abcd",
+    "vlessRoute.info": "مقدار مسیر اختیاری برای هاست‌های VLESS. باید دقیقاً شامل ۴ کاراکتر هگزادسیمال باشد. برای استفاده از مسیر پیش‌فرض خالی بگذارید."
   },
   "inbound": "ورودی",
   "inbounds": "ورودی‌ها",

--- a/dashboard/public/statics/locales/ru.json
+++ b/dashboard/public/statics/locales/ru.json
@@ -1285,10 +1285,29 @@
     "nextPlanDataLimit": "Лимит данных (ГБ)",
     "nextPlanExpire": "Срок действия (дней)",
     "nextPlanAddRemainingTraffic": "Добавить оставшийся трафик",
-    "routingSettings": "Routing",
-    "vlessRoute": "VLESS Route",
-    "vlessRoutePlaceholder": "e.g. abcd",
-    "vlessRoute.info": "Optional route value for VLESS hosts. Must be exactly 4 hexadecimal characters (0-9, a-f, A-F). Leave empty to use default routing."
+    "clientTemplateOverrides": "Шаблоны клиентов",
+    "clientTemplateOverridesDescription": "Оставьте поля пустыми, чтобы использовать обычные шаблоны по умолчанию.",
+    "clearOverrides": "Очистить все",
+    "useDefaultTemplate": "По умолчанию",
+    "clientTemplatePlaceholder": "Использовать шаблон по умолчанию",
+    "clientTemplateTypes": {
+      "clashSubscription": "Clash / Clash Meta",
+      "xraySubscription": "Xray",
+      "singboxSubscription": "Sing-box",
+      "userAgent": "User-Agent",
+      "grpcUserAgent": "gRPC User-Agent"
+    },
+    "clientTemplateTypeDescriptions": {
+      "clashSubscription": "Переопределить YAML-шаблон Clash для этого хоста.",
+      "xraySubscription": "Переопределить JSON-шаблон Xray для этого хоста.",
+      "singboxSubscription": "Переопределить JSON-шаблон sing-box для этого хоста.",
+      "userAgent": "Переопределить пул HTTP User-Agent для этого хоста.",
+      "grpcUserAgent": "Переопределить пул gRPC User-Agent для этого хоста."
+    },
+    "routingSettings": "Маршрутизация",
+    "vlessRoute": "Маршрут VLESS",
+    "vlessRoutePlaceholder": "например abcd",
+    "vlessRoute.info": "Необязательное значение маршрута для VLESS-хостов. Должно состоять ровно из 4 шестнадцатеричных символов. Оставьте пустым, чтобы использовать маршрут по умолчанию."
   },
   "enable": "Включить",
   "host": {

--- a/dashboard/public/statics/locales/zh.json
+++ b/dashboard/public/statics/locales/zh.json
@@ -1102,10 +1102,29 @@
     "nextPlanDataLimit": "数据限制 (GB)",
     "nextPlanExpire": "有效期 (天)",
     "nextPlanAddRemainingTraffic": "添加剩余流量",
-    "routingSettings": "Routing",
-    "vlessRoute": "VLESS Route",
-    "vlessRoutePlaceholder": "e.g. abcd",
-    "vlessRoute.info": "Optional route value for VLESS hosts. Must be exactly 4 hexadecimal characters (0-9, a-f, A-F). Leave empty to use default routing."
+    "clientTemplateOverrides": "客户端模板",
+    "clientTemplateOverridesDescription": "留空即可继续使用默认模板。",
+    "clearOverrides": "清除全部",
+    "useDefaultTemplate": "默认",
+    "clientTemplatePlaceholder": "使用默认模板",
+    "clientTemplateTypes": {
+      "clashSubscription": "Clash / Clash Meta",
+      "xraySubscription": "Xray",
+      "singboxSubscription": "Sing-box",
+      "userAgent": "User-Agent",
+      "grpcUserAgent": "gRPC User-Agent"
+    },
+    "clientTemplateTypeDescriptions": {
+      "clashSubscription": "为此主机覆盖 Clash 的 YAML 模板。",
+      "xraySubscription": "为此主机覆盖 Xray 的 JSON 模板。",
+      "singboxSubscription": "为此主机覆盖 sing-box 的 JSON 模板。",
+      "userAgent": "为此主机覆盖 HTTP User-Agent 池。",
+      "grpcUserAgent": "为此主机覆盖 gRPC User-Agent 池。"
+    },
+    "routingSettings": "路由",
+    "vlessRoute": "VLESS 路由",
+    "vlessRoutePlaceholder": "例如 abcd",
+    "vlessRoute.info": "VLESS 主机的可选路由值。必须正好为 4 位十六进制字符。留空则使用默认路由。"
   },
   "inbound": "入站",
   "inbounds": "入站",

--- a/dashboard/src/components/dialogs/host-modal.tsx
+++ b/dashboard/src/components/dialogs/host-modal.tsx
@@ -12,10 +12,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { VariablesList, VariablesPopover } from '@/components/ui/variables-popover'
 import useDirDetection from '@/hooks/use-dir-detection'
 import { cn } from '@/lib/utils'
-import { UserStatus, getHosts, getInbounds } from '@/service/api'
+import { UserStatus, getClientTemplatesSimple, getHosts, getInbounds } from '@/service/api'
 import { queryClient } from '@/utils/query-client'
 import { useQuery } from '@tanstack/react-query'
-import { Cable, Check, ChevronsLeftRightEllipsis, Copy, Edit, GlobeLock, Info, Loader2, Lock, Network, Plus, Route, Trash2, X } from 'lucide-react'
+import { Cable, Check, ChevronsLeftRightEllipsis, Copy, Edit, GlobeLock, Info, LayoutTemplate, Loader2, Lock, Network, Plus, Route, Trash2, X } from 'lucide-react'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -38,6 +38,39 @@ const statusOptions = [
   { value: UserStatus.limited, label: 'hostsDialog.status.limited' },
   { value: UserStatus.expired, label: 'hostsDialog.status.expired' },
   { value: UserStatus.on_hold, label: 'hostsDialog.status.onHold' },
+] as const
+
+const hostTemplateFieldOptions = [
+  {
+    field: 'client_template_ids.clash_subscription' as const,
+    type: 'clash_subscription',
+    label: 'hostsDialog.clientTemplateTypes.clashSubscription',
+    description: 'hostsDialog.clientTemplateTypeDescriptions.clashSubscription',
+  },
+  {
+    field: 'client_template_ids.xray_subscription' as const,
+    type: 'xray_subscription',
+    label: 'hostsDialog.clientTemplateTypes.xraySubscription',
+    description: 'hostsDialog.clientTemplateTypeDescriptions.xraySubscription',
+  },
+  {
+    field: 'client_template_ids.singbox_subscription' as const,
+    type: 'singbox_subscription',
+    label: 'hostsDialog.clientTemplateTypes.singboxSubscription',
+    description: 'hostsDialog.clientTemplateTypeDescriptions.singboxSubscription',
+  },
+  {
+    field: 'client_template_ids.user_agent' as const,
+    type: 'user_agent',
+    label: 'hostsDialog.clientTemplateTypes.userAgent',
+    description: 'hostsDialog.clientTemplateTypeDescriptions.userAgent',
+  },
+  {
+    field: 'client_template_ids.grpc_user_agent' as const,
+    type: 'grpc_user_agent',
+    label: 'hostsDialog.clientTemplateTypes.grpcUserAgent',
+    description: 'hostsDialog.clientTemplateTypeDescriptions.grpcUserAgent',
+  },
 ] as const
 
 // Memoized Noise Item Component for optimal performance
@@ -440,6 +473,57 @@ const ArrayInput = memo<ArrayInputProps>(({ field, placeholder, label, infoConte
 
 ArrayInput.displayName = 'ArrayInput'
 
+interface TemplateOverrideFieldProps {
+  fieldName: (typeof hostTemplateFieldOptions)[number]['field']
+  templateType: (typeof hostTemplateFieldOptions)[number]['type']
+  label: string
+  description: string
+  form: UseFormReturn<HostFormValues>
+  dir: 'ltr' | 'rtl'
+  isLoading: boolean
+  templates: Array<{ id: number; name: string; template_type: string; is_default: boolean }>
+  t: (key: string, options?: Record<string, unknown>) => string
+}
+
+const TemplateOverrideField = memo<TemplateOverrideFieldProps>(({ fieldName, templateType, label, description: _description, form, dir, isLoading, templates, t }) => (
+  <FormField
+    control={form.control}
+    name={fieldName}
+    render={({ field }) => (
+      <FormItem className="space-y-1">
+        <FormLabel className="text-xs font-medium text-muted-foreground">{label}</FormLabel>
+        <Select
+          dir={dir}
+          onValueChange={value => field.onChange(value === '__default__' ? undefined : Number.parseInt(value, 10))}
+          value={field.value != null ? String(field.value) : '__default__'}
+          disabled={isLoading}
+        >
+          <FormControl>
+            <SelectTrigger className="h-10">
+              <SelectValue placeholder={t('hostsDialog.clientTemplatePlaceholder', { defaultValue: 'Follow default template' })} />
+            </SelectTrigger>
+          </FormControl>
+          <SelectContent dir={dir}>
+            <SelectItem value="__default__">
+              {t('hostsDialog.useDefaultTemplate', { defaultValue: 'Follow default template' })}
+            </SelectItem>
+            {templates
+              .filter(template => template.template_type === templateType && !template.is_default)
+              .map(template => (
+                <SelectItem key={template.id} value={String(template.id)}>
+                  {template.name}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+        <FormMessage />
+      </FormItem>
+    )}
+  />
+))
+
+TemplateOverrideField.displayName = 'TemplateOverrideField'
+
 const HostModal: React.FC<HostModalProps> = ({ isDialogOpen, onOpenChange, onSubmit, editingHost, form }) => {
   const [openSection, setOpenSection] = useState<string | undefined>(undefined)
   const [isTransportOpen, setIsTransportOpen] = useState(false)
@@ -447,6 +531,8 @@ const HostModal: React.FC<HostModalProps> = ({ isDialogOpen, onOpenChange, onSub
   const dir = useDirDetection()
   const [_isSubmitting, setIsSubmitting] = useState(false)
   const xPaddingObfsEnabled = form.watch('transport_settings.xhttp_settings.x_padding_obfs_mode') === true
+  const watchedTemplateIds = form.watch('client_template_ids')
+  const selectedTemplateOverrideCount = Object.values(watchedTemplateIds || {}).filter(Boolean).length
 
   // Optimized noise settings handlers with useCallback for performance
   const addNoiseSetting = useCallback(() => {
@@ -570,6 +656,12 @@ const HostModal: React.FC<HostModalProps> = ({ isDialogOpen, onOpenChange, onSub
     enabled: isDialogOpen,
   })
 
+  const { data: clientTemplatesData, isLoading: isLoadingClientTemplates } = useQuery({
+    queryKey: ['/api/client_templates/simple'],
+    queryFn: () => getClientTemplatesSimple(),
+    enabled: isDialogOpen,
+  })
+
   // Update the hosts query to refetch only when needed (not on dialog open)
   const { data: hosts = [], isLoading: isLoadingHosts } = useQuery({
     queryKey: ['getHostsQueryKey'],
@@ -596,8 +688,8 @@ const HostModal: React.FC<HostModalProps> = ({ isDialogOpen, onOpenChange, onSub
       // If SingBox fragment is disabled, clear related fields
       if (!payload.fragment_settings?.sing_box?.fragment && payload.fragment_settings?.sing_box) {
         const singBox = payload.fragment_settings.sing_box!
-        ;(singBox as any).fragment_fallback_delay = undefined
-        ;(singBox as any).record_fragment = undefined
+          ; (singBox as any).fragment_fallback_delay = undefined
+          ; (singBox as any).record_fragment = undefined
       }
 
       // Convert fragment_fallback_delay number to ms format
@@ -3131,6 +3223,48 @@ const HostModal: React.FC<HostModalProps> = ({ isDialogOpen, onOpenChange, onSub
                         </FormItem>
                       )}
                     />
+                  </AccordionContent>
+                </AccordionItem>
+
+                <AccordionItem className="rounded-sm border px-4 [&_[data-state=closed]]:no-underline [&_[data-state=open]]:no-underline" value="template-overrides">
+                  <AccordionTrigger>
+                    <div className="flex min-w-0 items-center gap-2">
+                      <LayoutTemplate className="h-4 w-4" />
+                      <span>{t('hostsDialog.clientTemplateOverrides')}</span>
+                      <Badge variant={selectedTemplateOverrideCount > 0 ? 'default' : 'secondary'} className="ml-1">
+                        {selectedTemplateOverrideCount > 0 ? selectedTemplateOverrideCount : t('hostsDialog.useDefaultTemplate')}
+                      </Badge>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="px-2">
+                    <div className="mb-3 flex items-center justify-between gap-3">
+                      <p className="text-xs text-muted-foreground">{t('hostsDialog.clientTemplateOverridesDescription')}</p>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={selectedTemplateOverrideCount === 0}
+                        onClick={() => form.setValue('client_template_ids', undefined, { shouldDirty: true, shouldTouch: true })}
+                      >
+                        {t('hostsDialog.clearOverrides')}
+                      </Button>
+                    </div>
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                      {hostTemplateFieldOptions.map(option => (
+                        <TemplateOverrideField
+                          key={option.field}
+                          fieldName={option.field}
+                          templateType={option.type}
+                          label={t(option.label)}
+                          description={t(option.description)}
+                          form={form}
+                          dir={dir}
+                          isLoading={isLoadingClientTemplates}
+                          templates={clientTemplatesData?.templates || []}
+                          t={t}
+                        />
+                      ))}
+                    </div>
                   </AccordionContent>
                 </AccordionItem>
 

--- a/dashboard/src/components/forms/host-form.ts
+++ b/dashboard/src/components/forms/host-form.ts
@@ -47,6 +47,13 @@ export interface HostFormValues {
   address: string[]
   port?: number
   inbound_tag: string
+  client_template_ids?: {
+    clash_subscription?: number
+    xray_subscription?: number
+    singbox_subscription?: number
+    user_agent?: number
+    grpc_user_agent?: number
+  }
   status: ('active' | 'disabled' | 'limited' | 'expired' | 'on_hold')[]
   host?: string[]
   sni?: string[]
@@ -310,6 +317,15 @@ export const HostFormSchema = z.object({
   address: z.array(z.string()).min(1, 'At least one address is required'),
   port: z.number().min(1, 'Port must be at least 1').max(65535, 'Port must be at most 65535').optional().or(z.literal('')),
   inbound_tag: z.string().min(1, 'Inbound tag is required'),
+  client_template_ids: z
+    .object({
+      clash_subscription: z.number().int().positive().optional(),
+      xray_subscription: z.number().int().positive().optional(),
+      singbox_subscription: z.number().int().positive().optional(),
+      user_agent: z.number().int().positive().optional(),
+      grpc_user_agent: z.number().int().positive().optional(),
+    })
+    .optional(),
   status: z.array(z.string()).default([]),
   host: z.array(z.string()).default([]),
   sni: z.array(z.string()).default([]),
@@ -432,6 +448,7 @@ export const hostFormDefaultValues: HostFormValues = {
   address: [],
   port: undefined,
   inbound_tag: '',
+  client_template_ids: undefined,
   status: [],
   host: [],
   sni: [],

--- a/dashboard/src/components/hosts/hosts-list.tsx
+++ b/dashboard/src/components/hosts/hosts-list.tsx
@@ -137,6 +137,15 @@ export default function HostsList({ data, onAddHost, isDialogOpen, onSubmit, edi
       address: Array.isArray(host.address) ? host.address : host.address ? [host.address] : [],
       port: host.port ? Number(host.port) : undefined,
       inbound_tag: host.inbound_tag || '',
+      client_template_ids: host.client_template_ids
+        ? {
+            clash_subscription: host.client_template_ids.clash_subscription ?? undefined,
+            xray_subscription: host.client_template_ids.xray_subscription ?? undefined,
+            singbox_subscription: host.client_template_ids.singbox_subscription ?? undefined,
+            user_agent: host.client_template_ids.user_agent ?? undefined,
+            grpc_user_agent: host.client_template_ids.grpc_user_agent ?? undefined,
+          }
+        : undefined,
       status: host.status || [],
       host: Array.isArray(host.host) ? host.host : host.host ? [host.host] : [],
       sni: Array.isArray(host.sni) ? host.sni : host.sni ? [host.sni] : [],
@@ -308,6 +317,7 @@ export default function HostsList({ data, onAddHost, isDialogOpen, onSubmit, edi
         address: host.address || [],
         port: host.port,
         inbound_tag: host.inbound_tag || '',
+        client_template_ids: host.client_template_ids || undefined,
         status: host.status || [],
         host: host.host || [],
         sni: host.sni || [],
@@ -422,6 +432,7 @@ export default function HostsList({ data, onAddHost, isDialogOpen, onSubmit, edi
         address: host.address || [],
         port: host.port,
         inbound_tag: host.inbound_tag || '',
+        client_template_ids: host.client_template_ids || undefined,
         status: host.status || [],
         host: host.host || [],
         sni: host.sni || [],

--- a/dashboard/src/pages/_dashboard.hosts.tsx
+++ b/dashboard/src/pages/_dashboard.hosts.tsx
@@ -56,6 +56,15 @@ export default function HostsPage() {
       const hostData: CreateHost = {
         ...formData,
         priority,
+        client_template_ids: formData.client_template_ids
+          ? {
+              clash_subscription: formData.client_template_ids.clash_subscription || undefined,
+              xray_subscription: formData.client_template_ids.xray_subscription || undefined,
+              singbox_subscription: formData.client_template_ids.singbox_subscription || undefined,
+              user_agent: formData.client_template_ids.user_agent || undefined,
+              grpc_user_agent: formData.client_template_ids.grpc_user_agent || undefined,
+            }
+          : undefined,
         alpn: formData.alpn as ProxyHostALPN[] | undefined,
         fingerprint: formData.fingerprint as ProxyHostFingerprint | undefined,
         ech_config_list: formData.ech_config_list || undefined,

--- a/dashboard/src/service/api/index.ts
+++ b/dashboard/src/service/api/index.ts
@@ -1960,6 +1960,14 @@ export interface CreateUserFromTemplate {
   username: string
 }
 
+export interface HostClientTemplateIds {
+  clash_subscription?: number | null
+  xray_subscription?: number | null
+  singbox_subscription?: number | null
+  user_agent?: number | null
+  grpc_user_agent?: number | null
+}
+
 export type CreateHostVerifyPeerCertByName = string[] | null
 
 export type CreateHostPinnedPeerCertSha256 = string | null
@@ -2000,11 +2008,14 @@ export type CreateHostInboundTag = string | null
 
 export type CreateHostId = number | null
 
+export type CreateHostClientTemplateIds = HostClientTemplateIds | null
+
 export interface CreateHost {
   id?: CreateHostId
   remark: string
   address?: string[]
   inbound_tag?: CreateHostInboundTag
+  client_template_ids?: CreateHostClientTemplateIds
   port?: CreateHostPort
   sni?: CreateHostSni
   host?: CreateHostHost
@@ -2293,11 +2304,14 @@ export type BaseHostInboundTag = string | null
 
 export type BaseHostId = number | null
 
+export type BaseHostClientTemplateIds = HostClientTemplateIds | null
+
 export interface BaseHost {
   id?: BaseHostId
   remark: string
   address?: string[]
   inbound_tag?: BaseHostInboundTag
+  client_template_ids?: BaseHostClientTemplateIds
   port?: BaseHostPort
   sni?: BaseHostSni
   host?: BaseHostHost

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -1,7 +1,7 @@
 from fastapi import status
 
 from tests.api import client
-from tests.api.helpers import create_core, delete_core, get_inbounds, unique_name
+from tests.api.helpers import create_client_template, create_core, delete_client_template, delete_core, get_inbounds, unique_name
 
 
 def test_host_create(access_token):
@@ -11,6 +11,12 @@ def test_host_create(access_token):
     inbounds = get_inbounds(access_token)
     assert inbounds, "No inbounds available for host creation"
     created_hosts = []
+    xray_template = create_client_template(
+        access_token,
+        name=unique_name("host_xray_template"),
+        template_type="xray_subscription",
+        content='{"metadata":{"marker":"host-create"},"outbounds":[{"tag":"direct","protocol":"freedom","settings":{}}],"inbounds":[{"tag":"proxy","protocol":"vmess","settings":{"clients":[{"id":"00000000-0000-0000-0000-000000000000","alterId":0}]}}]}',
+    )
 
     try:
         for idx, inbound in enumerate(inbounds[:3]):
@@ -20,6 +26,7 @@ def test_host_create(access_token):
                 "port": 443,
                 "sni": [f"test_sni_{idx}.com"],
                 "inbound_tag": inbound,
+                "client_template_ids": {"xray_subscription": xray_template["id"]} if idx == 0 else None,
                 "priority": idx + 1,
                 "vless_route": "6967" if idx == 0 else None,  # Only test vless_route on the first host
             }
@@ -35,9 +42,12 @@ def test_host_create(access_token):
             assert response.json()["port"] == payload["port"]
             assert response.json()["sni"] == payload["sni"]
             assert response.json()["inbound_tag"] == inbound
+            if idx == 0:
+                assert response.json()["client_template_ids"]["xray_subscription"] == xray_template["id"]
     finally:
         for host_id in created_hosts:
             client.delete(f"/api/host/{host_id}", headers={"Authorization": f"Bearer {access_token}"})
+        delete_client_template(access_token, xray_template["id"])
         delete_core(access_token, core["id"])
 
 
@@ -75,6 +85,12 @@ def test_host_update(access_token):
     inbound_list = get_inbounds(access_token)
     assert inbound_list, "No inbounds available for host updates"
     inbound = inbound_list[0]
+    clash_template = create_client_template(
+        access_token,
+        name=unique_name("host_clash_template"),
+        template_type="clash_subscription",
+        content="proxies: []\nproxy-groups: []\nrules: []\n",
+    )
     create_response = client.post(
         "/api/host",
         headers={"Authorization": f"Bearer {access_token}"},
@@ -98,6 +114,7 @@ def test_host_update(access_token):
             "port": 443,
             "sni": ["test_sni_updated.com"],
             "inbound_tag": "Trojan Websocket TLS",
+            "client_template_ids": {"clash_subscription": clash_template["id"]},
         },
     )
     assert response.status_code == status.HTTP_200_OK
@@ -107,7 +124,9 @@ def test_host_update(access_token):
     assert response.json()["sni"] == ["test_sni_updated.com"]
     assert response.json()["priority"] == 666
     assert response.json()["inbound_tag"] == "Trojan Websocket TLS"
+    assert response.json()["client_template_ids"]["clash_subscription"] == clash_template["id"]
     client.delete(f"/api/host/{host_id}", headers={"Authorization": f"Bearer {access_token}"})
+    delete_client_template(access_token, clash_template["id"])
     delete_core(access_token, core["id"])
 
 

--- a/tests/api/test_user.py
+++ b/tests/api/test_user.py
@@ -4,11 +4,13 @@ from fastapi import status
 
 from tests.api import client
 from tests.api.helpers import (
+    create_client_template,
     create_core,
     create_group,
     create_user,
     create_user_template,
     create_hosts_for_inbounds,
+    delete_client_template,
     delete_core,
     delete_group,
     delete_user,
@@ -174,6 +176,52 @@ def test_user_subscriptions(access_token):
         delete_user(access_token, user["username"])
         for host in hosts:
             client.delete(f"/api/host/{host['id']}", headers={"Authorization": f"Bearer {access_token}"})
+        cleanup_groups(access_token, core, groups)
+
+
+def test_user_xray_subscription_uses_host_template_override(access_token):
+    core, groups = setup_groups(access_token, 1)
+    marker = unique_name("host_xray_marker")
+    template = create_client_template(
+        access_token,
+        name=unique_name("host_xray_override"),
+        template_type="xray_subscription",
+        content=(
+            '{"metadata":{"marker":"'
+            + marker
+            + '"},"outbounds":[{"tag":"direct","protocol":"freedom","settings":{}}],"inbounds":[{"tag":"proxy","protocol":"vmess","settings":{"clients":[{"id":"00000000-0000-0000-0000-000000000000","alterId":0}]}}]}'
+        ),
+    )
+    inbounds = [group["inbound_tags"][0] for group in groups if group.get("inbound_tags")]
+    assert inbounds, "No inbound tag available for host template override test"
+    host_response = client.post(
+        "/api/host",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={
+            "remark": unique_name("host_override"),
+            "address": ["127.0.0.1"],
+            "port": 443,
+            "sni": ["override.example.com"],
+            "inbound_tag": inbounds[0],
+            "client_template_ids": {"xray_subscription": template["id"]},
+            "priority": 1,
+        },
+    )
+    assert host_response.status_code == status.HTTP_201_CREATED
+    host = host_response.json()
+    user = create_user(
+        access_token,
+        group_ids=[group["id"] for group in groups],
+        payload={"username": unique_name("test_user_host_template_override")},
+    )
+    try:
+        response = client.get(f"{user['subscription_url']}/xray")
+        assert response.status_code == status.HTTP_200_OK
+        assert marker in response.text
+    finally:
+        delete_user(access_token, user["username"])
+        client.delete(f"/api/host/{host['id']}", headers={"Authorization": f"Bearer {access_token}"})
+        delete_client_template(access_token, template["id"])
         cleanup_groups(access_token, core, groups)
 
 


### PR DESCRIPTION
**Summary**

This PR adds per-host client template overrides so each host can choose custom client templates by output type while preserving existing default fallback behavior.

It introduces a single host-side `client_template_ids` field to store optional overrides for:
- Clash / Clash Meta subscription template
- Xray subscription template
- Sing-box subscription template
- HTTP User-Agent template
- gRPC User-Agent template

When an override is not set, invalid, deleted, or not consistently applicable for the rendered request, subscription generation falls back to the existing default template behavior.

**Backend Changes**

- Added `client_template_ids` JSON storage on hosts with migration support.
- Exposed the override structure in host API models and cached subscription host data.
- Added backend validation to ensure each configured host override points to a client template of the correct type.
- Extended client-template cache/catalog loading to support lookup by template id as well as by default template type.
- Updated subscription rendering to resolve host-level template overrides per request and fall back safely to defaults.

**Dashboard Changes**

- Added host form support for per-type client template overrides.
- Updated host create/edit/duplicate/reorder flows to preserve `client_template_ids`.
- Added a compact host modal section under Routing for managing overrides.
- Excluded default templates from override dropdowns to avoid showing the same default choice twice.
- Added translations for the new host template UI in English, Persian, Russian, and Chinese.

**Notes**

- Storage uses a single JSON host column instead of one database column per template type.
- I did not complete a full automated test pass in this environment.