### PR TITLE
feat(subscription): align sing-box generation and defaults with latest schema

### DIFF
--- a/app/db/migrations/versions/e8c6a4f1d2b7_add_client_templates_table.py
+++ b/app/db/migrations/versions/e8c6a4f1d2b7_add_client_templates_table.py
@@ -150,20 +150,14 @@ DEFAULT_SINGBOX_SUBSCRIPTION_TEMPLATE = """{
   "dns": {
     "servers": [
       {
+        "type": "udp",
         "tag": "dns-remote",
-        "address": "1.1.1.2",
+        "server": "1.1.1.2",
         "detour": "proxy"
       },
       {
-        "tag": "dns-local",
-        "address": "local",
-        "detour": "direct"
-      }
-    ],
-    "rules": [
-      {
-        "outbound": "any",
-        "server": "dns-local"
+        "type": "local",
+        "tag": "dns-local"
       }
     ],
     "final": "dns-remote"
@@ -223,7 +217,7 @@ DEFAULT_SINGBOX_SUBSCRIPTION_TEMPLATE = """{
   "experimental": {
     "cache_file": {
       "enabled": true,
-      "store_rdrc": true
+      "store_dns": true
     }
   }
 }"""

--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -70,7 +70,6 @@ class SingBoxConfiguration(BaseSubscription):
             "tuic",
             "http",
             "ssh",
-            "wireguard",
             "urltest",
         ]
         selector_tags = [outbound["tag"] for outbound in self.config["outbounds"] if outbound["type"] in selector_types]
@@ -104,10 +103,13 @@ class SingBoxConfiguration(BaseSubscription):
         if not handler:
             return
 
-        # Build outbound
-        outbound = handler(remark=remark, address=address, inbound=inbound, settings=settings)
-        if outbound:
-            self.add_outbound(outbound)
+        # Build outbound or WireGuard endpoint (sing-box 1.11+)
+        built = handler(remark=remark, address=address, inbound=inbound, settings=settings)
+        if built:
+            if inbound.protocol == "wireguard":
+                self.add_endpoint(built)
+            else:
+                self.add_outbound(built)
 
     # ========== Transport Handlers ==========
 
@@ -187,7 +189,7 @@ class SingBoxConfiguration(BaseSubscription):
         }
 
         if config.random_user_agent:
-            transport["headers"]["User-Agent"] = choice(self.user_agent_list)
+            transport["headers"]["User-Agent"] = [choice(self.user_agent_list)]
 
         return self._normalize_and_remove_none_values(transport)
 
@@ -260,7 +262,7 @@ class SingBoxConfiguration(BaseSubscription):
             remark=remark,
             address=address,
             inbound=inbound,
-            user_settings={"uuid": str(settings["id"]), "alterId": 0},
+            user_settings={"uuid": str(settings["id"]), "alter_id": 0},
         )
 
     def _build_vless(self, remark: str, address: str, inbound: SubscriptionInboundData, settings: dict) -> dict:
@@ -331,12 +333,21 @@ class SingBoxConfiguration(BaseSubscription):
                 "type": "salamander",
                 "password": obfs_password,
             }
-        config["server_ports"] = [quic_params.get("udpHop", {}).get("ports", "")]
-        config["hop_interval"] = (
-            f"{quic_params.get('udpHop', {}).get('hopInterval', '')}s"
-            if quic_params.get("udpHop", {}).get("interval")
-            else None
-        )
+        udp_hop = quic_params.get("udpHop") or {}
+        hop_ports = udp_hop.get("ports")
+        if hop_ports:
+            config["server_ports"] = [hop_ports] if isinstance(hop_ports, str) else hop_ports
+        hop_iv = udp_hop.get("hopInterval") or udp_hop.get("interval")
+        if hop_iv:
+            hop_iv = str(hop_iv).rstrip("s")
+            config["hop_interval"] = f"{hop_iv}s"
+        hop_max = udp_hop.get("hopIntervalMax") or udp_hop.get("hop_interval_max")
+        if hop_max:
+            hop_max = str(hop_max).rstrip("s")
+            config["hop_interval_max"] = f"{hop_max}s"
+        bbr_profile = quic_params.get("bbrProfile") or quic_params.get("bbr_profile")
+        if bbr_profile:
+            config["bbr_profile"] = bbr_profile
         config["brutal_debug"] = quic_params.get("debug", False)
         up = re.search(pattern, str(quic_params.get("brutalUp")))
         down = re.search(pattern, str(quic_params.get("brutalDown")))
@@ -352,7 +363,7 @@ class SingBoxConfiguration(BaseSubscription):
     def _build_wireguard(
         self, remark: str, address: str, inbound: SubscriptionInboundData, settings: dict
     ) -> dict | None:
-        """Build WireGuard outbound for sing-box subscriptions."""
+        """Build WireGuard endpoint for sing-box subscriptions (replaces deprecated outbound)."""
         private_key = settings.get("private_key", "")
         peer_ips = list(settings.get("peer_ips") or [])
         public_key = inbound.wireguard_public_key
@@ -364,8 +375,8 @@ class SingBoxConfiguration(BaseSubscription):
         reserved = self._parse_wireguard_reserved(inbound.wireguard_reserved)
 
         peer = {
-            "server": address,
-            "server_port": selected_port,
+            "address": address,
+            "port": selected_port,
             "public_key": public_key,
             "pre_shared_key": inbound.wireguard_pre_shared_key or None,
             "allowed_ips": allowed_ips,
@@ -373,25 +384,18 @@ class SingBoxConfiguration(BaseSubscription):
             "reserved": reserved,
         }
 
-        outbound = {
+        endpoint = {
             "type": "wireguard",
             "tag": remark,
-            "server": address,
-            "server_port": selected_port,
-            "system_interface": True,
-            "gso": True,
-            "interface_name": "wg0",
+            "system": True,
+            "name": "wg0",
             "mtu": inbound.wireguard_mtu,
-            "local_address": peer_ips,
+            "address": peer_ips,
             "private_key": private_key,
-            "peer_public_key": public_key,
-            "pre_shared_key": inbound.wireguard_pre_shared_key or None,
-            "reserved": reserved,
             "peers": [self._normalize_and_remove_none_values(peer)],
-            "workers": 4,
         }
 
-        return self._normalize_and_remove_none_values(outbound)
+        return self._normalize_and_remove_none_values(endpoint)
 
     def _build_outbound(
         self,

--- a/dashboard/src/components/forms/client-template-form.ts
+++ b/dashboard/src/components/forms/client-template-form.ts
@@ -126,20 +126,14 @@ rules:
       dns: {
         servers: [
           {
+            type: 'udp',
             tag: 'dns-remote',
-            address: '1.1.1.2',
+            server: '1.1.1.2',
             detour: 'proxy',
           },
           {
+            type: 'local',
             tag: 'dns-local',
-            address: 'local',
-            detour: 'direct',
-          },
-        ],
-        rules: [
-          {
-            outbound: 'any',
-            server: 'dns-local',
           },
         ],
         final: 'dns-remote',
@@ -187,7 +181,7 @@ rules:
         override_android_vpn: true,
       },
       experimental: {
-        cache_file: { enabled: true, store_rdrc: true },
+        cache_file: { enabled: true, store_dns: true },
       },
     },
     null,

--- a/tests/api/test_user.py
+++ b/tests/api/test_user.py
@@ -584,7 +584,7 @@ def test_xray_subscription_template_override_isolated_per_host(access_token):
         delete_core(access_token, core["id"])
 
 
-def test_singbox_subscription_includes_wireguard_outbound(access_token):
+def test_singbox_subscription_includes_wireguard_endpoint(access_token):
     interface_private_key, interface_public_key = generate_wireguard_keypair()
     pre_shared_key, _ = generate_wireguard_keypair()
     interface_name = unique_name("wg_singbox_subscription")
@@ -632,30 +632,26 @@ def test_singbox_subscription_includes_wireguard_outbound(access_token):
         assert response.status_code == status.HTTP_200_OK
 
         config = response.json()
-        wireguard_outbound = next(
-            (outbound for outbound in config.get("outbounds", []) if outbound.get("type") == "wireguard"), None
+        wireguard_ep = next(
+            (ep for ep in config.get("endpoints", []) if ep.get("type") == "wireguard"),
+            None,
         )
-        assert wireguard_outbound is not None
-        assert wireguard_outbound["tag"] == expected_tag
-        assert wireguard_outbound["system_interface"] is True
-        assert wireguard_outbound["interface_name"] == "wg0"
-        assert wireguard_outbound["mtu"] == 1408
-        assert wireguard_outbound["local_address"]
-        assert wireguard_outbound["local_address"][0] == user["proxy_settings"]["wireguard"]["peer_ips"][0]
-        assert wireguard_outbound["local_address"][0].startswith("10.")
-        assert wireguard_outbound["local_address"][0].endswith("/32")
-        assert wireguard_outbound["private_key"] == user["proxy_settings"]["wireguard"]["private_key"]
-        assert wireguard_outbound["server"] == endpoint
-        assert wireguard_outbound["server_port"] == 10001
-        assert wireguard_outbound["peer_public_key"] == interface_public_key
-        assert wireguard_outbound["pre_shared_key"] == pre_shared_key
-        assert wireguard_outbound["reserved"] == [0, 0, 0]
+        assert wireguard_ep is not None
+        assert wireguard_ep["tag"] == expected_tag
+        assert wireguard_ep["system"] is True
+        assert wireguard_ep["name"] == "wg0"
+        assert wireguard_ep["mtu"] == 1408
+        assert wireguard_ep["address"]
+        assert wireguard_ep["address"][0] == user["proxy_settings"]["wireguard"]["peer_ips"][0]
+        assert wireguard_ep["address"][0].startswith("10.")
+        assert wireguard_ep["address"][0].endswith("/32")
+        assert wireguard_ep["private_key"] == user["proxy_settings"]["wireguard"]["private_key"]
 
-        peers = wireguard_outbound["peers"]
+        peers = wireguard_ep["peers"]
         assert len(peers) == 1
         peer = peers[0]
-        assert peer["server"] == endpoint
-        assert peer["server_port"] == 10001
+        assert peer["address"] == endpoint
+        assert peer["port"] == 10001
         assert peer["public_key"] == interface_public_key
         assert peer["pre_shared_key"] == pre_shared_key
         assert peer["allowed_ips"] == ["0.0.0.0/0", "::/0"]


### PR DESCRIPTION
### summary
This pull request updates sing-box subscription generation and the default client template so they match current sing-box behavior and documentation.

WireGuard nodes are emitted as **`endpoints`** entries using **`peers[].address`** and **`peers[].port`**, instead of the deprecated WireGuard outbound shape. VMess now uses **`alter_id`**. Hysteria2 port hopping and optional **`bbr_profile`** / **`hop_interval_max`** are derived from QUIC parameters when present, and HTTPUpgrade **`User-Agent`** is formatted like other transports. The default template switches to **typed DNS servers** (UDP + local) and replaces deprecated **`store_rdrc`** with **`store_dns`** on the experimental cache file.
