### PR TITLE
Enable flow_enabled for VLESS when inbound encryption is set

### DIFF
--- a/app/core/hosts.py
+++ b/app/core/hosts.py
@@ -257,11 +257,16 @@ async def _prepare_subscription_inbound_data(
 
     # Compute flow_enabled: only for VLESS with specific conditions
     header_type = getattr(transport_config, "header_type", "none")
-    flow_enabled = (
+    base_flow_enabled = (
         protocol == "vless"
         and tls_value in ("tls", "reality")
         and network in ("tcp", "raw", "kcp")
         and header_type != "http"
+    )
+
+    # Enable also when inbound vless encryption is enabled (not "none")
+    flow_enabled = base_flow_enabled or (
+        protocol == "vless" and encryption not in (None, "", "none")
     )
 
     return SubscriptionInboundData(


### PR DESCRIPTION
### What
- Refactor `flow_enabled` calculation in `app/core/hosts.py`:
  - Keep the existing strict conditions as `base_flow_enabled`.
  - Additionally set `flow_enabled=True` for **VLESS** when inbound `encryption` is enabled (`encryption` not in `None`, `""`, `"none"`).

### Why
Some VLESS setups use **VLESS Encryption** (e.g. with XTLS Vision) and expect “flow”/optimized behavior to be treated as enabled even when the previous TLS+transport constraints don’t match. This change makes the flag align better with VLESS encryption usage and avoids missing flow in encrypted VLESS configs.

References:
- XTLS VLESS inbound docs (VLESS Encryption):  
  https://xtls.github.io/en/config/inbounds/vless.html#:~:text=VLESS%20Encryption%3A%20No%20underlying%20transport%20restrictions.%20If%20the%20underlying%20layer%20does%20not%20support%20direct%20copying%20(see%20above)%2C%20it%20only%20penetrates%20Encryption.
- motivation (VLESS Encryption + XTLS Vision performance):  
  https://xraycore.org/en/misc/vless-encryption/#2-%D1%81-xtls-vision-%D0%BC%D0%B0%D0%BA%D1%81%D0%B8%D0%BC%D0%B0%D0%BB%D1%8C%D0%BD%D0%B0%D1%8F-%D0%BF%D1%80%D0%BE%D0%B8%D0%B7%D0%B2%D0%BE%D0%B4%D0%B8%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%BE%D1%81%D1%82%D1%8C

### Verification
- Tested locally using docker compose.
- Confirmed behavior is unchanged when `encryption: "none"` (in that case `flow_enabled` still depends only on the original `base_flow_enabled` conditions).

### Notes
- Change is scoped to `protocol == "vless"` only.
- No impact on other protocols/transports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated flow configuration logic to enable flow under broader protocol and encryption combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->