### PR TITLE
feat: Add ID-based user and admin API routes

### DIFF
--- a/app/core/hosts.py
+++ b/app/core/hosts.py
@@ -197,15 +197,21 @@ async def _prepare_subscription_inbound_data(
             no_grpc_header=xs.no_grpc_header if xs else None,
             sc_max_each_post_bytes=xs.sc_max_each_post_bytes if xs else None,
             sc_min_posts_interval_ms=xs.sc_min_posts_interval_ms if xs else None,
-            x_padding_bytes=xs.x_padding_bytes if xs and xs.x_padding_bytes is not None else inbound_config.get("x_padding_bytes"),
+            x_padding_bytes=xs.x_padding_bytes
+            if xs and xs.x_padding_bytes is not None
+            else inbound_config.get("x_padding_bytes"),
             x_padding_obfs_mode=(
                 xs.x_padding_obfs_mode
                 if xs and xs.x_padding_obfs_mode is not None
                 else inbound_config.get("x_padding_obfs_mode")
             ),
-            x_padding_key=xs.x_padding_key if xs and xs.x_padding_key is not None else inbound_config.get("x_padding_key"),
+            x_padding_key=xs.x_padding_key
+            if xs and xs.x_padding_key is not None
+            else inbound_config.get("x_padding_key"),
             x_padding_header=(
-                xs.x_padding_header if xs and xs.x_padding_header is not None else inbound_config.get("x_padding_header")
+                xs.x_padding_header
+                if xs and xs.x_padding_header is not None
+                else inbound_config.get("x_padding_header")
             ),
             x_padding_placement=(
                 xs.x_padding_placement
@@ -213,13 +219,19 @@ async def _prepare_subscription_inbound_data(
                 else inbound_config.get("x_padding_placement")
             ),
             x_padding_method=(
-                xs.x_padding_method if xs and xs.x_padding_method is not None else inbound_config.get("x_padding_method")
+                xs.x_padding_method
+                if xs and xs.x_padding_method is not None
+                else inbound_config.get("x_padding_method")
             ),
             uplink_http_method=(
-                xs.uplink_http_method if xs and xs.uplink_http_method is not None else inbound_config.get("uplink_http_method")
+                xs.uplink_http_method
+                if xs and xs.uplink_http_method is not None
+                else inbound_config.get("uplink_http_method")
             ),
             session_placement=(
-                xs.session_placement if xs and xs.session_placement is not None else inbound_config.get("session_placement")
+                xs.session_placement
+                if xs and xs.session_placement is not None
+                else inbound_config.get("session_placement")
             ),
             session_key=xs.session_key if xs and xs.session_key is not None else inbound_config.get("session_key"),
             seq_placement=(
@@ -235,7 +247,9 @@ async def _prepare_subscription_inbound_data(
                 xs.uplink_data_key if xs and xs.uplink_data_key is not None else inbound_config.get("uplink_data_key")
             ),
             uplink_chunk_size=(
-                xs.uplink_chunk_size if xs and xs.uplink_chunk_size is not None else inbound_config.get("uplink_chunk_size")
+                xs.uplink_chunk_size
+                if xs and xs.uplink_chunk_size is not None
+                else inbound_config.get("uplink_chunk_size")
             ),
             xmux=xs.xmux.model_dump(by_alias=True, exclude_none=True) if xs and xs.xmux else None,
             download_settings=down_settings if xs and down_settings else None,

--- a/app/db/crud/admin.py
+++ b/app/db/crud/admin.py
@@ -166,7 +166,7 @@ async def get_admin_by_id(
     Returns:
         Admin: The admin object.
     """
-    admin = (await db.execute(select(Admin).where(Admin.id == id))).first()
+    admin = (await db.execute(select(Admin).where(Admin.id == id))).unique().scalar_one_or_none()
     if admin:
         await load_admin_attrs(admin, load_users=load_users, load_usage_logs=load_usage_logs)
     return admin

--- a/app/models/admin.py
+++ b/app/models/admin.py
@@ -139,6 +139,7 @@ class AdminInDB(AdminDetails):
 
 
 class AdminValidationResult(BaseModel):
+    id: int | None = None
     username: str
     is_sudo: bool
     is_disabled: bool

--- a/app/operation/__init__.py
+++ b/app/operation/__init__.py
@@ -142,7 +142,13 @@ class BaseOperation:
         if not sub:
             await self.raise_error(message="Not Found", code=404)
 
-        db_user = await get_user(db, sub["username"])
+        if "user_id" in sub:
+            db_user = await get_user_by_id(db, sub["user_id"])
+        elif "username" in sub:
+            db_user = await get_user(db, sub["username"])
+        else:
+            await self.raise_error(message="Not Found", code=404)
+
         if not db_user or db_user.created_at.astimezone(tz.utc) > sub["created_at"]:
             await self.raise_error(message="Not Found", code=404)
 

--- a/app/operation/admin.py
+++ b/app/operation/admin.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 from datetime import datetime as dt
 
 from sqlalchemy.exc import IntegrityError
@@ -77,8 +78,19 @@ class AdminOperation(BaseOperation):
     async def modify_admin(
         self, db: AsyncSession, username: str, modified_admin: AdminModify, current_admin: AdminDetails
     ) -> AdminDetails:
-        """Modify an existing admin's details."""
+        warnings.warn(
+            "modify_admin(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use modify_admin_by_id(admin_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_admin = await self.get_validated_admin(db, username=username)
+        return await self._modify_admin(db, db_admin, modified_admin, current_admin)
+
+    async def _modify_admin(
+        self, db: AsyncSession, db_admin: Admin, modified_admin: AdminModify, current_admin: AdminDetails
+    ) -> AdminDetails:
+        """Modify an existing admin's details."""
         if self.operator_type != OperatorType.CLI and not db_admin.is_sudo and modified_admin.is_sudo:
             await self.raise_error(
                 message="Promoting admin to sudo via API is not allowed. Use pasarguard cli / tui instead.", code=403
@@ -110,9 +122,24 @@ class AdminOperation(BaseOperation):
         asyncio.create_task(notification.modify_admin(modified_admin, current_admin.username))
         return modified_admin
 
+    async def modify_admin_by_id(
+        self, db: AsyncSession, admin_id: int, modified_admin: AdminModify, current_admin: AdminDetails
+    ) -> AdminDetails:
+        db_admin = await self.get_validated_admin_by_id(db, admin_id)
+        return await self._modify_admin(db, db_admin, modified_admin, current_admin)
+
     async def remove_admin(self, db: AsyncSession, username: str, current_admin: AdminDetails | None = None):
-        """Remove an admin from the database."""
+        warnings.warn(
+            "remove_admin(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use remove_admin_by_id(admin_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_admin = await self.get_validated_admin(db, username=username)
+        await self._remove_admin(db, db_admin, current_admin)
+
+    async def _remove_admin(self, db: AsyncSession, db_admin: Admin, current_admin: AdminDetails | None = None):
+        """Remove an admin from the database."""
         if self.operator_type != OperatorType.CLI and db_admin.is_sudo:
             await self.raise_error(
                 message="You're not allowed to remove sudoer's account. Use pasarguard cli / tui instead.", code=403
@@ -123,7 +150,11 @@ class AdminOperation(BaseOperation):
             logger.info(
                 f'Admin "{db_admin.username}" with id "{db_admin.id}" deleted by admin "{current_admin.username}"'
             )
-            asyncio.create_task(notification.remove_admin(username, current_admin.username))
+            asyncio.create_task(notification.remove_admin(db_admin.username, current_admin.username))
+
+    async def remove_admin_by_id(self, db: AsyncSession, admin_id: int, current_admin: AdminDetails | None = None):
+        db_admin = await self.get_validated_admin_by_id(db, admin_id)
+        await self._remove_admin(db, db_admin, current_admin)
 
     async def get_admins(
         self,
@@ -202,9 +233,17 @@ class AdminOperation(BaseOperation):
         return await get_admins_count(db)
 
     async def disable_all_active_users(self, db: AsyncSession, username: str, admin: AdminDetails):
-        """Disable all active users under a specific admin"""
+        warnings.warn(
+            "disable_all_active_users(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use disable_all_active_users_by_id(admin_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_admin = await self.get_validated_admin(db, username=username)
+        await self._disable_all_active_users_for_admin(db, db_admin, admin)
 
+    async def _disable_all_active_users_for_admin(self, db: AsyncSession, db_admin: Admin, admin: AdminDetails):
+        """Disable all active users under a specific admin"""
         if db_admin.is_sudo:
             await self.raise_error(message="You're not allowed to disable sudo admin users.", code=403)
 
@@ -213,12 +252,24 @@ class AdminOperation(BaseOperation):
         users = await get_users(db, admin=db_admin)
         await sync_users(users)
 
-        logger.info(f'Admin "{username}" users has been disabled by admin "{admin.username}"')
+        logger.info(f'Admin "{db_admin.username}" users has been disabled by admin "{admin.username}"')
+
+    async def disable_all_active_users_by_id(self, db: AsyncSession, admin_id: int, admin: AdminDetails):
+        db_admin = await self.get_validated_admin_by_id(db, admin_id)
+        await self._disable_all_active_users_for_admin(db, db_admin, admin)
 
     async def activate_all_disabled_users(self, db: AsyncSession, username: str, admin: AdminDetails):
-        """Enable all active users under a specific admin"""
+        warnings.warn(
+            "activate_all_disabled_users(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use activate_all_disabled_users_by_id(admin_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_admin = await self.get_validated_admin(db, username=username)
+        await self._activate_all_disabled_users_for_admin(db, db_admin, admin)
 
+    async def _activate_all_disabled_users_for_admin(self, db: AsyncSession, db_admin: Admin, admin: AdminDetails):
+        """Enable all active users under a specific admin"""
         if db_admin.is_sudo:
             await self.raise_error(message="You're not allowed to enable sudo admin users.", code=403)
 
@@ -227,11 +278,24 @@ class AdminOperation(BaseOperation):
         users = await get_users(db, admin=db_admin)
         await sync_users(users)
 
-        logger.info(f'Admin "{username}" users has been activated by admin "{admin.username}"')
+        logger.info(f'Admin "{db_admin.username}" users has been activated by admin "{admin.username}"')
+
+    async def activate_all_disabled_users_by_id(self, db: AsyncSession, admin_id: int, admin: AdminDetails):
+        db_admin = await self.get_validated_admin_by_id(db, admin_id)
+        await self._activate_all_disabled_users_for_admin(db, db_admin, admin)
 
     async def remove_all_users(self, db: AsyncSession, username: str, admin: AdminDetails) -> int:
-        """Delete all users that belong to the specified admin."""
+        warnings.warn(
+            "remove_all_users(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use remove_all_users_by_id(admin_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_admin = await self.get_validated_admin(db, username=username)
+        return await self._remove_all_users_for_admin(db, db_admin, admin)
+
+    async def _remove_all_users_for_admin(self, db: AsyncSession, db_admin: Admin, admin: AdminDetails) -> int:
+        """Delete all users that belong to the specified admin."""
         target_username = db_admin.username
 
         if self.operator_type != OperatorType.CLI and db_admin.is_sudo:
@@ -256,17 +320,33 @@ class AdminOperation(BaseOperation):
         )
         return len(serialized_users)
 
-    async def reset_admin_usage(self, db: AsyncSession, username: str, admin: AdminDetails) -> AdminDetails:
-        db_admin = await self.get_validated_admin(db, username=username)
+    async def remove_all_users_by_id(self, db: AsyncSession, admin_id: int, admin: AdminDetails) -> int:
+        db_admin = await self.get_validated_admin_by_id(db, admin_id)
+        return await self._remove_all_users_for_admin(db, db_admin, admin)
 
+    async def reset_admin_usage(self, db: AsyncSession, username: str, admin: AdminDetails) -> AdminDetails:
+        warnings.warn(
+            "reset_admin_usage(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use reset_admin_usage_by_id(admin_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        db_admin = await self.get_validated_admin(db, username=username)
+        return await self._reset_admin_usage(db, db_admin, admin)
+
+    async def _reset_admin_usage(self, db: AsyncSession, db_admin: Admin, admin: AdminDetails) -> AdminDetails:
         db_admin = await reset_admin_usage(db, db_admin=db_admin)
         if self.operator_type != OperatorType.CLI:
-            logger.info(f'Admin "{username}" usage has been reset by admin "{admin.username}"')
+            logger.info(f'Admin "{db_admin.username}" usage has been reset by admin "{admin.username}"')
 
-        reseted_admin = AdminDetails.model_validate(db_admin)
-        asyncio.create_task(notification.admin_usage_reset(reseted_admin, admin.username))
+        reseted_admin_details = AdminDetails.model_validate(db_admin)
+        asyncio.create_task(notification.admin_usage_reset(reseted_admin_details, admin.username))
 
-        return reseted_admin
+        return reseted_admin_details
+
+    async def reset_admin_usage_by_id(self, db: AsyncSession, admin_id: int, admin: AdminDetails) -> AdminDetails:
+        db_admin = await self.get_validated_admin_by_id(db, admin_id)
+        return await self._reset_admin_usage(db, db_admin, admin)
 
     async def get_admin_usage(
         self,
@@ -279,20 +359,70 @@ class AdminOperation(BaseOperation):
         node_id: int | None = None,
         group_by_node: bool = False,
     ) -> UserUsageStatsList:
+        warnings.warn(
+            "get_admin_usage(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use get_admin_usage_by_id(admin_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        db_admin = await self.get_validated_admin(db, username=username)
+        return await self._get_admin_usage(
+            db,
+            db_admin,
+            admin,
+            start=start,
+            end=end,
+            period=period,
+            node_id=node_id,
+            group_by_node=group_by_node,
+        )
+
+    async def _get_admin_usage(
+        self,
+        db: AsyncSession,
+        db_admin: Admin,
+        admin: AdminDetails,
+        start: dt = None,
+        end: dt = None,
+        period: Period = Period.hour,
+        node_id: int | None = None,
+        group_by_node: bool = False,
+    ) -> UserUsageStatsList:
         """Get aggregated usage for an admin's users."""
         start, end = await self.validate_dates(start, end, True)
 
         if not admin.is_sudo:
-            if username != admin.username:
+            if db_admin.username != admin.username:
                 await self.raise_error(message="You're not allowed", code=403)
             node_id = None
             group_by_node = False
 
-        db_admin = await self.get_validated_admin(db, username=username)
-
         return await get_admin_usages(
             db=db,
             admin_id=db_admin.id,
+            start=start,
+            end=end,
+            period=period,
+            node_id=node_id,
+            group_by_node=group_by_node,
+        )
+
+    async def get_admin_usage_by_id(
+        self,
+        db: AsyncSession,
+        admin_id: int,
+        admin: AdminDetails,
+        start: dt = None,
+        end: dt = None,
+        period: Period = Period.hour,
+        node_id: int | None = None,
+        group_by_node: bool = False,
+    ) -> UserUsageStatsList:
+        db_admin = await self.get_validated_admin_by_id(db, admin_id)
+        return await self._get_admin_usage(
+            db,
+            db_admin,
+            admin,
             start=start,
             end=end,
             period=period,
@@ -420,7 +550,7 @@ class AdminOperation(BaseOperation):
             await self._ensure_can_manage_admin_users(db_admin, action="disable")
 
         for db_admin in db_admins:
-            await self.disable_all_active_users(db, username=db_admin.username, admin=admin)
+            await self._disable_all_active_users_for_admin(db, db_admin, admin)
 
         return self._build_bulk_action_response(db_admins)
 
@@ -433,7 +563,7 @@ class AdminOperation(BaseOperation):
             await self._ensure_can_manage_admin_users(db_admin, action="activate")
 
         for db_admin in db_admins:
-            await self.activate_all_disabled_users(db, username=db_admin.username, admin=admin)
+            await self._activate_all_disabled_users_for_admin(db, db_admin, admin)
 
         return self._build_bulk_action_response(db_admins)
 
@@ -446,6 +576,6 @@ class AdminOperation(BaseOperation):
             await self._ensure_can_manage_admin_users(db_admin, action="remove")
 
         for db_admin in db_admins:
-            await self.remove_all_users(db, username=db_admin.username, admin=admin)
+            await self._remove_all_users_for_admin(db, db_admin, admin)
 
         return self._build_bulk_action_response(db_admins)

--- a/app/operation/user.py
+++ b/app/operation/user.py
@@ -609,8 +609,7 @@ class UserOperation(BaseOperation):
     ) -> UserResponse:
         """Set a new owner (admin) for a user."""
         warnings.warn(
-            "set_owner(username, ...) is deprecated and will be removed in v6.0.0. "
-            "Use set_owner_by_id(user_id, ...).",
+            "set_owner(username, ...) is deprecated and will be removed in v6.0.0. Use set_owner_by_id(user_id, ...).",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -695,8 +694,7 @@ class UserOperation(BaseOperation):
 
     async def get_user(self, db: AsyncSession, username: str, admin: AdminDetails) -> UserNotificationResponse:
         warnings.warn(
-            "get_user(username, ...) is deprecated and will be removed in v6.0.0. "
-            "Use get_user_by_id(user_id, ...).",
+            "get_user(username, ...) is deprecated and will be removed in v6.0.0. Use get_user_by_id(user_id, ...).",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/app/operation/user.py
+++ b/app/operation/user.py
@@ -1,6 +1,7 @@
 import asyncio
 import re
 import secrets
+import warnings
 from collections import Counter
 from datetime import datetime as dt, timedelta as td, timezone as tz
 from typing import Literal
@@ -110,7 +111,7 @@ class UserOperation(BaseOperation):
             if user.admin and user.admin.sub_domain
             else (settings.url_prefix).replace("*", salt)
         )
-        token = await create_subscription_token(user.username)
+        token = await create_subscription_token(user.id)
         return f"{url_prefix}/{SUBSCRIPTION_PATH}/{token}"
 
     async def _generate_usernames(
@@ -356,21 +357,44 @@ class UserOperation(BaseOperation):
     async def modify_user(
         self, db: AsyncSession, username: str, modified_user: UserModify, admin: AdminDetails
     ) -> UserResponse:
+        warnings.warn(
+            "modify_user(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use modify_user_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_user = await self.get_validated_user(db, username, admin)
 
         return await self._modify_user(db, db_user, modified_user, admin)
 
-    async def remove_user(self, db: AsyncSession, username: str, admin: AdminDetails):
-        db_user = await self.get_validated_user(db, username, admin)
+    async def modify_user_by_id(
+        self, db: AsyncSession, user_id: int, modified_user: UserModify, admin: AdminDetails
+    ) -> UserResponse:
+        db_user = await self.get_validated_user_by_id(db, user_id, admin)
+        return await self._modify_user(db, db_user, modified_user, admin)
 
+    async def _remove_user(self, db: AsyncSession, db_user: User, admin: AdminDetails) -> dict:
         user = await self.validate_user(db_user, include_subscription_url=False)
         await remove_user(db, db_user)
         await sync_remove_user(user)
 
         asyncio.create_task(notification.remove_user(user, admin))
-
         logger.info(f'User "{db_user.username}" with id "{db_user.id}" deleted by admin "{admin.username}"')
         return {}
+
+    async def remove_user(self, db: AsyncSession, username: str, admin: AdminDetails):
+        warnings.warn(
+            "remove_user(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use remove_user_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        db_user = await self.get_validated_user(db, username, admin)
+        return await self._remove_user(db, db_user, admin)
+
+    async def remove_user_by_id(self, db: AsyncSession, user_id: int, admin: AdminDetails):
+        db_user = await self.get_validated_user_by_id(db, user_id, admin)
+        return await self._remove_user(db, db_user, admin)
 
     async def _get_validated_users_by_ids(
         self,
@@ -441,8 +465,18 @@ class UserOperation(BaseOperation):
         return user
 
     async def reset_user_data_usage(self, db: AsyncSession, username: str, admin: AdminDetails):
+        warnings.warn(
+            "reset_user_data_usage(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use reset_user_data_usage_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_user = await self.get_validated_user(db, username, admin)
 
+        return await self._reset_user_data_usage(db, db_user, admin)
+
+    async def reset_user_data_usage_by_id(self, db: AsyncSession, user_id: int, admin: AdminDetails):
+        db_user = await self.get_validated_user_by_id(db, user_id, admin)
         return await self._reset_user_data_usage(db, db_user, admin)
 
     async def bulk_reset_user_data_usage(
@@ -463,17 +497,28 @@ class UserOperation(BaseOperation):
 
         return self._build_bulk_action_response(users)
 
-    async def revoke_user_sub(self, db: AsyncSession, username: str, admin: AdminDetails) -> UserResponse:
-        db_user = await self.get_validated_user(db, username, admin)
-
+    async def _revoke_user_sub(self, db: AsyncSession, db_user: User, admin: AdminDetails) -> UserResponse:
         db_user = await revoke_user_sub(db=db, db_user=db_user)
         user = await self.update_user(db_user)
 
         asyncio.create_task(notification.user_subscription_revoked(user, admin))
-
         logger.info(f'User "{db_user.username}" subscription was revoked by admin "{admin.username}"')
 
         return user
+
+    async def revoke_user_sub(self, db: AsyncSession, username: str, admin: AdminDetails) -> UserResponse:
+        warnings.warn(
+            "revoke_user_sub(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use revoke_user_sub_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        db_user = await self.get_validated_user(db, username, admin)
+        return await self._revoke_user_sub(db, db_user, admin)
+
+    async def revoke_user_sub_by_id(self, db: AsyncSession, user_id: int, admin: AdminDetails) -> UserResponse:
+        db_user = await self.get_validated_user_by_id(db, user_id, admin, load_usage_logs=False)
+        return await self._revoke_user_sub(db, db_user, admin)
 
     async def bulk_revoke_user_sub(
         self, db: AsyncSession, bulk_users: BulkUsersSelection, admin: AdminDetails
@@ -521,40 +566,64 @@ class UserOperation(BaseOperation):
         db_admin = await self.get_validated_admin(db, admin.username)
         await reset_all_users_data_usage(db=db, admin=db_admin)
 
-    async def active_next_plan(self, db: AsyncSession, username: str, admin: AdminDetails) -> UserResponse:
-        """Reset user by next plan"""
-        db_user = await self.get_validated_user(db, username, admin)
-
+    async def _active_next_plan(self, db: AsyncSession, db_user: User, admin: AdminDetails) -> UserResponse:
         if db_user is None or db_user.next_plan is None:
             await self.raise_error(message="User doesn't have next plan", code=404)
 
         old_status = db_user.status
-
         db_user = await reset_user_by_next(db=db, db_user=db_user)
-
         user = await self.update_user(db_user)
 
         if user.status != old_status:
             asyncio.create_task(notification.user_status_change(user, admin))
 
         asyncio.create_task(notification.user_data_reset_by_next(user, admin))
-
         logger.info(f'User "{db_user.username}"\'s usage was reset by next plan by admin "{admin.username}"')
+        return user
 
+    async def active_next_plan(self, db: AsyncSession, username: str, admin: AdminDetails) -> UserResponse:
+        """Reset user by next plan"""
+        warnings.warn(
+            "active_next_plan(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use active_next_plan_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        db_user = await self.get_validated_user(db, username, admin)
+        return await self._active_next_plan(db, db_user, admin)
+
+    async def active_next_plan_by_id(self, db: AsyncSession, user_id: int, admin: AdminDetails) -> UserResponse:
+        db_user = await self.get_validated_user_by_id(db, user_id, admin)
+        return await self._active_next_plan(db, db_user, admin)
+
+    async def _set_owner(self, db: AsyncSession, db_user: User, new_admin, admin: AdminDetails) -> UserResponse:
+        db_user = await set_owner(db, db_user, new_admin)
+        user = await self.validate_user(db_user)
+        logger.info(
+            f'User "{user.username}" owner successfully set to "{new_admin.username}" by admin "{admin.username}"'
+        )
         return user
 
     async def set_owner(
         self, db: AsyncSession, username: str, admin_username: str, admin: AdminDetails
     ) -> UserResponse:
         """Set a new owner (admin) for a user."""
+        warnings.warn(
+            "set_owner(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use set_owner_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         new_admin = await self.get_validated_admin(db, username=admin_username)
         db_user = await self.get_validated_user(db, username, admin)
+        return await self._set_owner(db, db_user, new_admin, admin)
 
-        db_user = await set_owner(db, db_user, new_admin)
-        user = await self.validate_user(db_user)
-        logger.info(f'{user.username}"owner successfully set to{new_admin.username} by admin "{admin.username}"')
-
-        return user
+    async def set_owner_by_id(
+        self, db: AsyncSession, user_id: int, admin_username: str, admin: AdminDetails
+    ) -> UserResponse:
+        new_admin = await self.get_validated_admin(db, username=admin_username)
+        db_user = await self.get_validated_user_by_id(db, user_id, admin)
+        return await self._set_owner(db, db_user, new_admin, admin)
 
     async def bulk_set_owner(
         self, db: AsyncSession, bulk_users: BulkUsersSetOwner, admin: AdminDetails
@@ -571,6 +640,25 @@ class UserOperation(BaseOperation):
 
         return self._build_bulk_action_response(users)
 
+    async def _get_user_usage(
+        self,
+        db: AsyncSession,
+        db_user: User,
+        admin: AdminDetails,
+        start: dt = None,
+        end: dt = None,
+        period: Period = Period.hour,
+        node_id: int | None = None,
+        group_by_node: bool = False,
+    ) -> UserUsageStatsList:
+        start, end = await self.validate_dates(start, end, True)
+
+        if not admin.is_sudo:
+            node_id = None
+            group_by_node = False
+
+        return await get_user_usages(db, db_user.id, start, end, period, node_id=node_id, group_by_node=group_by_node)
+
     async def get_user_usage(
         self,
         db: AsyncSession,
@@ -582,16 +670,36 @@ class UserOperation(BaseOperation):
         node_id: int | None = None,
         group_by_node: bool = False,
     ) -> UserUsageStatsList:
-        start, end = await self.validate_dates(start, end, True)
+        warnings.warn(
+            "get_user_usage(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use get_user_usage_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_user = await self.get_validated_user(db, username, admin)
+        return await self._get_user_usage(db, db_user, admin, start, end, period, node_id, group_by_node)
 
-        if not admin.is_sudo:
-            node_id = None
-            group_by_node = False
-
-        return await get_user_usages(db, db_user.id, start, end, period, node_id=node_id, group_by_node=group_by_node)
+    async def get_user_usage_by_id(
+        self,
+        db: AsyncSession,
+        user_id: int,
+        admin: AdminDetails,
+        start: dt = None,
+        end: dt = None,
+        period: Period = Period.hour,
+        node_id: int | None = None,
+        group_by_node: bool = False,
+    ) -> UserUsageStatsList:
+        db_user = await self.get_validated_user_by_id(db, user_id, admin)
+        return await self._get_user_usage(db, db_user, admin, start, end, period, node_id, group_by_node)
 
     async def get_user(self, db: AsyncSession, username: str, admin: AdminDetails) -> UserNotificationResponse:
+        warnings.warn(
+            "get_user(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use get_user_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_user = await self.get_validated_user(db, username, admin)
         return await self.validate_user(db_user)
 
@@ -869,10 +977,9 @@ class UserOperation(BaseOperation):
 
         return await self.create_user(db, new_user, admin)
 
-    async def modify_user_with_template(
-        self, db: AsyncSession, username: str, modified_template: ModifyUserByTemplate, admin: AdminDetails
+    async def _modify_user_with_template(
+        self, db: AsyncSession, db_user: User, modified_template: ModifyUserByTemplate, admin: AdminDetails
     ) -> UserResponse:
-        db_user = await self.get_validated_user(db, username, admin)
         original_status = db_user.status
         user_template = await self.get_validated_user_template(db, modified_template.user_template_id)
 
@@ -902,6 +1009,24 @@ class UserOperation(BaseOperation):
             )
 
         return await self._modify_user(db, db_user, modify_user, admin)
+
+    async def modify_user_with_template(
+        self, db: AsyncSession, username: str, modified_template: ModifyUserByTemplate, admin: AdminDetails
+    ) -> UserResponse:
+        warnings.warn(
+            "modify_user_with_template(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use modify_user_with_template_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        db_user = await self.get_validated_user(db, username, admin)
+        return await self._modify_user_with_template(db, db_user, modified_template, admin)
+
+    async def modify_user_with_template_by_id(
+        self, db: AsyncSession, user_id: int, modified_template: ModifyUserByTemplate, admin: AdminDetails
+    ) -> UserResponse:
+        db_user = await self.get_validated_user_by_id(db, user_id, admin)
+        return await self._modify_user_with_template(db, db_user, modified_template, admin)
 
     async def bulk_create_users_from_template(
         self, db: AsyncSession, bulk_users: BulkUsersFromTemplate, admin: AdminDetails
@@ -1050,22 +1175,50 @@ class UserOperation(BaseOperation):
         out = await run_wg_bulk(db, users, dry_run=body.dry_run, replace_all=body.replace_all)
         return WireGuardPeerIPsReallocateResponse(**out)
 
+    async def _get_users_sub_update_list(
+        self, db: AsyncSession, db_user: User, offset: int = 0, limit: int = 10
+    ) -> UserSubscriptionUpdateList:
+        user_sub_data, count = await get_users_sub_update_list(db, user_id=db_user.id, offset=offset, limit=limit)
+        return UserSubscriptionUpdateList(updates=user_sub_data, count=count)
+
     async def get_users_sub_update_list(
         self, db: AsyncSession, username: str, admin: AdminDetails, offset: int = 0, limit: int = 10
     ) -> UserSubscriptionUpdateList:
+        warnings.warn(
+            "get_users_sub_update_list(username, ...) is deprecated and will be removed in v6.0.0. "
+            "Use get_users_sub_update_list_by_id(user_id, ...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         db_user = await self.get_validated_user(db, username, admin)
-        user_sub_data, count = await get_users_sub_update_list(db, user_id=db_user.id, offset=offset, limit=limit)
+        return await self._get_users_sub_update_list(db, db_user, offset, limit)
 
-        return UserSubscriptionUpdateList(updates=user_sub_data, count=count)
+    async def get_users_sub_update_list_by_id(
+        self, db: AsyncSession, user_id: int, admin: AdminDetails, offset: int = 0, limit: int = 10
+    ) -> UserSubscriptionUpdateList:
+        db_user = await self.get_validated_user_by_id(db, user_id, admin)
+        return await self._get_users_sub_update_list(db, db_user, offset, limit)
 
     async def get_users_sub_update_chart(
         self,
         db: AsyncSession,
         admin: AdminDetails,
+        user_id: int | None = None,
         username: str | None = None,
         admin_id: int | None = None,
     ) -> UserSubscriptionUpdateChart:
+        if user_id is not None:
+            db_user = await self.get_validated_user_by_id(db, user_id, admin)
+            agent_counts = await get_users_subscription_agent_counts(db, user_id=db_user.id)
+            return self._build_user_agent_chart(agent_counts)
+
         if username:
+            warnings.warn(
+                "username filter for get_users_sub_update_chart(...) is deprecated and will be removed in v6.0.0. "
+                "Use user_id instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             db_user = await self.get_validated_user(db, username, admin)
             agent_counts = await get_users_subscription_agent_counts(db, user_id=db_user.id)
             return self._build_user_agent_chart(agent_counts)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -68,7 +68,7 @@ async def admin_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
     asyncio.create_task(notification.admin_login(db_admin.username, "", client_ip, True))
-    return Token(access_token=await create_admin_token(form_data.username, db_admin.is_sudo))
+    return Token(access_token=await create_admin_token(db_admin.id, form_data.username, db_admin.is_sudo))
 
 
 @router.post("/miniapp/token", responses={409: responses._409})
@@ -93,7 +93,7 @@ async def admin_mini_app_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
     asyncio.create_task(notification.admin_login(db_admin.username, "", client_ip, True))
-    return Token(access_token=await create_admin_token(db_admin.username, db_admin.is_sudo))
+    return Token(access_token=await create_admin_token(db_admin.id, db_admin.username, db_admin.is_sudo))
 
 
 @router.post(
@@ -126,12 +126,66 @@ async def modify_admin(
     )
 
 
+@router.put(
+    "/by-username/{username}",
+    response_model=AdminDetails,
+    responses={403: responses._403, 404: responses._404, 409: responses._409},
+)
+async def modify_admin_by_username(
+    username: str,
+    modified_admin: AdminModify,
+    db: AsyncSession = Depends(get_db),
+    current_admin: AdminDetails = Depends(check_sudo_admin),
+):
+    return await admin_operator.modify_admin(
+        db,
+        username=username,
+        modified_admin=modified_admin,
+        current_admin=current_admin,
+    )
+
+
+@router.put(
+    "/by-id/{admin_id}",
+    response_model=AdminDetails,
+    responses={403: responses._403, 404: responses._404, 409: responses._409},
+)
+async def modify_admin_by_id(
+    admin_id: int,
+    modified_admin: AdminModify,
+    db: AsyncSession = Depends(get_db),
+    current_admin: AdminDetails = Depends(check_sudo_admin),
+):
+    return await admin_operator.modify_admin_by_id(
+        db,
+        admin_id=admin_id,
+        modified_admin=modified_admin,
+        current_admin=current_admin,
+    )
+
+
 @router.delete("/{username}", status_code=status.HTTP_204_NO_CONTENT)
 async def remove_admin(
     username: str, db: AsyncSession = Depends(get_db), current_admin: AdminDetails = Depends(check_sudo_admin)
 ):
     """Remove an admin from the database."""
     await admin_operator.remove_admin(db, username=username, current_admin=current_admin)
+    return {}
+
+
+@router.delete("/by-username/{username}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_admin_by_username(
+    username: str, db: AsyncSession = Depends(get_db), current_admin: AdminDetails = Depends(check_sudo_admin)
+):
+    await admin_operator.remove_admin(db, username=username, current_admin=current_admin)
+    return {}
+
+
+@router.delete("/by-id/{admin_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_admin_by_id(
+    admin_id: int, db: AsyncSession = Depends(get_db), current_admin: AdminDetails = Depends(check_sudo_admin)
+):
+    await admin_operator.remove_admin_by_id(db, admin_id=admin_id, current_admin=current_admin)
     return {}
 
 
@@ -208,12 +262,82 @@ async def get_admin_usage(
     )
 
 
+@router.get(
+    "/by-username/{username}/usage",
+    response_model=UserUsageStatsList,
+    responses={403: responses._403, 404: responses._404},
+)
+async def get_admin_usage_by_username(
+    username: str,
+    period: Period,
+    node_id: int | None = None,
+    group_by_node: bool = False,
+    start: dt | None = Query(None, examples=["2024-01-01T00:00:00+03:30"]),
+    end: dt | None = Query(None, examples=["2024-01-31T23:59:59+03:30"]),
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await admin_operator.get_admin_usage(
+        db,
+        username=username,
+        admin=admin,
+        start=start,
+        end=end,
+        period=period,
+        node_id=node_id,
+        group_by_node=group_by_node,
+    )
+
+
+@router.get(
+    "/by-id/{admin_id}/usage",
+    response_model=UserUsageStatsList,
+    responses={403: responses._403, 404: responses._404},
+)
+async def get_admin_usage_by_id(
+    admin_id: int,
+    period: Period,
+    node_id: int | None = None,
+    group_by_node: bool = False,
+    start: dt | None = Query(None, examples=["2024-01-01T00:00:00+03:30"]),
+    end: dt | None = Query(None, examples=["2024-01-31T23:59:59+03:30"]),
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await admin_operator.get_admin_usage_by_id(
+        db,
+        admin_id=admin_id,
+        admin=admin,
+        start=start,
+        end=end,
+        period=period,
+        node_id=node_id,
+        group_by_node=group_by_node,
+    )
+
+
 @router.post("/{username}/users/disable", responses={404: responses._404})
 async def disable_all_active_users(
     username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
 ):
     """Disable all active users under a specific admin"""
     await admin_operator.disable_all_active_users(db, username=username, admin=admin)
+    return {}
+
+
+@router.post("/by-username/{username}/users/disable", responses={404: responses._404})
+async def disable_all_active_users_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
+):
+    await admin_operator.disable_all_active_users(db, username=username, admin=admin)
+    return {}
+
+
+@router.post("/by-id/{admin_id}/users/disable", responses={404: responses._404})
+async def disable_all_active_users_by_id(
+    admin_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
+):
+    await admin_operator.disable_all_active_users_by_id(db, admin_id=admin_id, admin=admin)
     return {}
 
 
@@ -226,6 +350,22 @@ async def activate_all_disabled_users(
     return {}
 
 
+@router.post("/by-username/{username}/users/activate", responses={404: responses._404})
+async def activate_all_disabled_users_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
+):
+    await admin_operator.activate_all_disabled_users(db, username=username, admin=admin)
+    return {}
+
+
+@router.post("/by-id/{admin_id}/users/activate", responses={404: responses._404})
+async def activate_all_disabled_users_by_id(
+    admin_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
+):
+    await admin_operator.activate_all_disabled_users_by_id(db, admin_id=admin_id, admin=admin)
+    return {}
+
+
 @router.delete("/{username}/users", responses={403: responses._403, 404: responses._404})
 async def remove_all_users(
     username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
@@ -235,12 +375,42 @@ async def remove_all_users(
     return {"detail": f"operation has been successfuly done {deleted} users deleted"}
 
 
+@router.delete("/by-username/{username}/users", responses={403: responses._403, 404: responses._404})
+async def remove_all_users_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
+):
+    deleted = await admin_operator.remove_all_users(db, username=username, admin=admin)
+    return {"detail": f"operation has been successfuly done {deleted} users deleted"}
+
+
+@router.delete("/by-id/{admin_id}/users", responses={403: responses._403, 404: responses._404})
+async def remove_all_users_by_id(
+    admin_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
+):
+    deleted = await admin_operator.remove_all_users_by_id(db, admin_id=admin_id, admin=admin)
+    return {"detail": f"operation has been successfuly done {deleted} users deleted"}
+
+
 @router.post("/{username}/reset", response_model=AdminDetails, responses={404: responses._404})
 async def reset_admin_usage(
     username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
 ):
     """Resets usage of admin."""
     return await admin_operator.reset_admin_usage(db, username=username, admin=admin)
+
+
+@router.post("/by-username/{username}/reset", response_model=AdminDetails, responses={404: responses._404})
+async def reset_admin_usage_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
+):
+    return await admin_operator.reset_admin_usage(db, username=username, admin=admin)
+
+
+@router.post("/by-id/{admin_id}/reset", response_model=AdminDetails, responses={404: responses._404})
+async def reset_admin_usage_by_id(
+    admin_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(check_sudo_admin)
+):
+    return await admin_operator.reset_admin_usage_by_id(db, admin_id=admin_id, admin=admin)
 
 
 @router.post(

--- a/app/routers/authentication.py
+++ b/app/routers/authentication.py
@@ -7,7 +7,12 @@ from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import func, select
 
 from app.db import AsyncSession, get_db
-from app.db.crud.admin import find_admins_by_telegram_id, get_admin as get_admin_by_username, get_admin_by_telegram_id
+from app.db.crud.admin import (
+    find_admins_by_telegram_id,
+    get_admin as get_admin_by_username,
+    get_admin_by_id as get_admin_by_id_crud,
+    get_admin_by_telegram_id,
+)
 from app.db.models import Admin, AdminUsageLogs, User
 from app.models.admin import AdminDetails, AdminValidationResult, verify_password
 from app.models.settings import Telegram
@@ -58,7 +63,13 @@ async def get_admin(db: AsyncSession, token: str) -> AdminDetails | None:
     if not payload:
         return
 
-    db_admin = await get_admin_by_username(db, payload["username"], load_users=False, load_usage_logs=False)
+    db_admin = None
+    if payload.get("admin_id") is not None:
+        db_admin = await get_admin_by_id_crud(db, payload["admin_id"], load_users=False, load_usage_logs=False)
+
+    if not db_admin:
+        db_admin = await get_admin_by_username(db, payload["username"], load_users=False, load_usage_logs=False)
+
     if db_admin:
         if not _is_token_valid_for_admin(db_admin, payload):
             return
@@ -83,11 +94,26 @@ async def get_admin_with_metrics(db: AsyncSession, token: str) -> AdminDetails |
         .correlate(Admin)
         .scalar_subquery()
     )
-    admin_row = (
-        await db.execute(
-            select(Admin, total_users_subquery, reseted_usage_subquery).where(Admin.username == payload["username"])
-        )
-    ).one_or_none()
+    if payload.get("admin_id") is not None:
+        admin_row = (
+            await db.execute(
+                select(Admin, total_users_subquery, reseted_usage_subquery).where(Admin.id == payload["admin_id"])
+            )
+        ).one_or_none()
+        if admin_row is None:
+            admin_row = (
+                await db.execute(
+                    select(Admin, total_users_subquery, reseted_usage_subquery).where(
+                        Admin.username == payload["username"]
+                    )
+                )
+            ).one_or_none()
+    else:
+        admin_row = (
+            await db.execute(
+                select(Admin, total_users_subquery, reseted_usage_subquery).where(Admin.username == payload["username"])
+            )
+        ).one_or_none()
 
     if admin_row:
         db_admin, total_users, reseted_usage = admin_row
@@ -148,7 +174,10 @@ async def validate_admin(db: AsyncSession, username: str, password: str) -> Admi
     db_admin = await get_admin_by_username(db, username, load_users=False, load_usage_logs=False)
     if db_admin and await verify_password(password, db_admin.hashed_password):
         return AdminValidationResult(
-            username=db_admin.username, is_sudo=db_admin.is_sudo, is_disabled=db_admin.is_disabled
+            id=db_admin.id,
+            username=db_admin.username,
+            is_sudo=db_admin.is_sudo,
+            is_disabled=db_admin.is_disabled,
         )
 
     if not db_admin and SUDOERS.get(username) == password:
@@ -187,5 +216,8 @@ async def validate_mini_app_admin(db: AsyncSession, token: str) -> AdminValidati
     db_admin = await get_admin_by_telegram_id(db, data.user.id, load_users=False, load_usage_logs=False)
     if db_admin:
         return AdminValidationResult(
-            username=db_admin.username, is_sudo=db_admin.is_sudo, is_disabled=db_admin.is_disabled
+            id=db_admin.id,
+            username=db_admin.username,
+            is_sudo=db_admin.is_sudo,
+            is_disabled=db_admin.is_disabled,
         )

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -152,7 +152,9 @@ async def remove_user_by_username(
     responses={403: responses._403, 404: responses._404},
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def remove_user_by_id(user_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)):
+async def remove_user_by_id(
+    user_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
     return await user_operator.remove_user_by_id(db, user_id=user_id, admin=admin)
 
 
@@ -175,7 +177,9 @@ async def reset_user_data_usage_by_username(
     return await user_operator.reset_user_data_usage(db, username=username, admin=admin)
 
 
-@router.post("/by-id/{user_id}/reset", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
+@router.post(
+    "/by-id/{user_id}/reset", response_model=UserResponse, responses={403: responses._403, 404: responses._404}
+)
 async def reset_user_data_usage_by_id(
     user_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
 ):
@@ -311,7 +315,9 @@ async def get_user(username: str, db: AsyncSession = Depends(get_db), admin: Adm
     return await user_operator.get_user(db=db, username=username, admin=admin)
 
 
-@router.get("/by-username/{username}", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
+@router.get(
+    "/by-username/{username}", response_model=UserResponse, responses={403: responses._403, 404: responses._404}
+)
 async def get_user_by_username(
     username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
 ):

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -100,12 +100,60 @@ async def modify_user(
     return await user_operator.modify_user(db, username=username, modified_user=modified_user, admin=admin)
 
 
+@router.put(
+    "/by-username/{username}",
+    response_model=UserResponse,
+    responses={400: responses._400, 403: responses._403, 404: responses._404},
+)
+async def modify_user_by_username(
+    username: str,
+    modified_user: UserModify,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await user_operator.modify_user(db, username=username, modified_user=modified_user, admin=admin)
+
+
+@router.put(
+    "/by-id/{user_id}",
+    response_model=UserResponse,
+    responses={400: responses._400, 403: responses._403, 404: responses._404},
+)
+async def modify_user_by_id(
+    user_id: int,
+    modified_user: UserModify,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await user_operator.modify_user_by_id(db, user_id=user_id, modified_user=modified_user, admin=admin)
+
+
 @router.delete(
     "/{username}", responses={403: responses._403, 404: responses._404}, status_code=status.HTTP_204_NO_CONTENT
 )
 async def remove_user(username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)):
     """Remove a user"""
     return await user_operator.remove_user(db, username=username, admin=admin)
+
+
+@router.delete(
+    "/by-username/{username}",
+    responses={403: responses._403, 404: responses._404},
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_user_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
+    return await user_operator.remove_user(db, username=username, admin=admin)
+
+
+@router.delete(
+    "/by-id/{user_id}",
+    responses={403: responses._403, 404: responses._404},
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_user_by_id(user_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)):
+    return await user_operator.remove_user_by_id(db, user_id=user_id, admin=admin)
 
 
 @router.post("/{username}/reset", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
@@ -117,6 +165,24 @@ async def reset_user_data_usage(
 
 
 @router.post(
+    "/by-username/{username}/reset",
+    response_model=UserResponse,
+    responses={403: responses._403, 404: responses._404},
+)
+async def reset_user_data_usage_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
+    return await user_operator.reset_user_data_usage(db, username=username, admin=admin)
+
+
+@router.post("/by-id/{user_id}/reset", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
+async def reset_user_data_usage_by_id(
+    user_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
+    return await user_operator.reset_user_data_usage_by_id(db, user_id=user_id, admin=admin)
+
+
+@router.post(
     "/{username}/revoke_sub", response_model=UserResponse, responses={403: responses._403, 404: responses._404}
 )
 async def revoke_user_subscription(
@@ -124,6 +190,28 @@ async def revoke_user_subscription(
 ):
     """Revoke users subscription (Subscription link and proxies)"""
     return await user_operator.revoke_user_sub(db, username=username, admin=admin)
+
+
+@router.post(
+    "/by-username/{username}/revoke_sub",
+    response_model=UserResponse,
+    responses={403: responses._403, 404: responses._404},
+)
+async def revoke_user_subscription_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
+    return await user_operator.revoke_user_sub(db, username=username, admin=admin)
+
+
+@router.post(
+    "/by-id/{user_id}/revoke_sub",
+    response_model=UserResponse,
+    responses={403: responses._403, 404: responses._404},
+)
+async def revoke_user_subscription_by_id(
+    user_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
+    return await user_operator.revoke_user_sub_by_id(db, user_id=user_id, admin=admin)
 
 
 @router.post("s/reset", responses={403: responses._403, 404: responses._404})
@@ -140,13 +228,20 @@ async def reset_users_data_usage(db: AsyncSession = Depends(get_db), admin: Admi
     responses={403: responses._403, 404: responses._404},
 )
 async def get_users_sub_update_chart(
+    user_id: int | None = None,
     username: str | None = None,
     admin_id: int | None = None,
     db: AsyncSession = Depends(get_db),
     admin: AdminDetails = Depends(get_current),
 ):
-    """Get subscription agent distribution percentages (optionally filtered by username)"""
-    return await user_operator.get_users_sub_update_chart(db, admin=admin, username=username, admin_id=admin_id)
+    """Get subscription agent distribution percentages (optionally filtered by user_id/username)."""
+    return await user_operator.get_users_sub_update_chart(
+        db,
+        admin=admin,
+        user_id=user_id,
+        username=username,
+        admin_id=admin_id,
+    )
 
 
 @router.put("/{username}/set_owner", response_model=UserResponse, responses={403: responses._403})
@@ -160,6 +255,26 @@ async def set_owner(
     return await user_operator.set_owner(db, username=username, admin_username=admin_username, admin=admin)
 
 
+@router.put("/by-username/{username}/set_owner", response_model=UserResponse, responses={403: responses._403})
+async def set_owner_by_username(
+    username: str,
+    admin_username: str,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(check_sudo_admin),
+):
+    return await user_operator.set_owner(db, username=username, admin_username=admin_username, admin=admin)
+
+
+@router.put("/by-id/{user_id}/set_owner", response_model=UserResponse, responses={403: responses._403})
+async def set_owner_by_id(
+    user_id: int,
+    admin_username: str,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(check_sudo_admin),
+):
+    return await user_operator.set_owner_by_id(db, user_id=user_id, admin_username=admin_username, admin=admin)
+
+
 @router.post(
     "/{username}/active_next", response_model=UserResponse, responses={403: responses._403, 404: responses._404}
 )
@@ -170,10 +285,42 @@ async def active_next_plan(
     return await user_operator.active_next_plan(db, username=username, admin=admin)
 
 
+@router.post(
+    "/by-username/{username}/active_next",
+    response_model=UserResponse,
+    responses={403: responses._403, 404: responses._404},
+)
+async def active_next_plan_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
+    return await user_operator.active_next_plan(db, username=username, admin=admin)
+
+
+@router.post(
+    "/by-id/{user_id}/active_next", response_model=UserResponse, responses={403: responses._403, 404: responses._404}
+)
+async def active_next_plan_by_id(
+    user_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
+    return await user_operator.active_next_plan_by_id(db, user_id=user_id, admin=admin)
+
+
 @router.get("/{username}", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
 async def get_user(username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)):
     """Get user information"""
     return await user_operator.get_user(db=db, username=username, admin=admin)
+
+
+@router.get("/by-username/{username}", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
+async def get_user_by_username(
+    username: str, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)
+):
+    return await user_operator.get_user(db=db, username=username, admin=admin)
+
+
+@router.get("/by-id/{user_id}", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
+async def get_user_by_id(user_id: int, db: AsyncSession = Depends(get_db), admin: AdminDetails = Depends(get_current)):
+    return await user_operator.get_user_by_id(db=db, user_id=user_id, admin=admin)
 
 
 @router.get(
@@ -190,6 +337,42 @@ async def get_user_sub_update_list(
 ):
     """Get user subscription agent list"""
     return await user_operator.get_users_sub_update_list(db, username=username, admin=admin, offset=offset, limit=limit)
+
+
+@router.get(
+    "/by-username/{username}/sub_update",
+    response_model=UserSubscriptionUpdateList,
+    responses={403: responses._403, 404: responses._404},
+)
+async def get_user_sub_update_list_by_username(
+    username: str,
+    offset: int = 0,
+    limit: int = 10,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await user_operator.get_users_sub_update_list(db, username=username, admin=admin, offset=offset, limit=limit)
+
+
+@router.get(
+    "/by-id/{user_id}/sub_update",
+    response_model=UserSubscriptionUpdateList,
+    responses={403: responses._403, 404: responses._404},
+)
+async def get_user_sub_update_list_by_id(
+    user_id: int,
+    offset: int = 0,
+    limit: int = 10,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await user_operator.get_users_sub_update_list_by_id(
+        db,
+        user_id=user_id,
+        admin=admin,
+        offset=offset,
+        limit=limit,
+    )
 
 
 @router.get(
@@ -271,6 +454,60 @@ async def get_user_usage(
     return await user_operator.get_user_usage(
         db,
         username=username,
+        admin=admin,
+        start=start,
+        end=end,
+        period=period,
+        node_id=node_id,
+        group_by_node=group_by_node,
+    )
+
+
+@router.get(
+    "/by-username/{username}/usage",
+    response_model=UserUsageStatsList,
+    responses={403: responses._403, 404: responses._404},
+)
+async def get_user_usage_by_username(
+    username: str,
+    period: Period,
+    node_id: int | None = None,
+    group_by_node: bool = False,
+    start: dt | None = Query(None, examples=["2024-01-01T00:00:00+03:30"]),
+    end: dt | None = Query(None, examples=["2024-01-31T23:59:59+03:30"]),
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await user_operator.get_user_usage(
+        db,
+        username=username,
+        admin=admin,
+        start=start,
+        end=end,
+        period=period,
+        node_id=node_id,
+        group_by_node=group_by_node,
+    )
+
+
+@router.get(
+    "/by-id/{user_id}/usage",
+    response_model=UserUsageStatsList,
+    responses={403: responses._403, 404: responses._404},
+)
+async def get_user_usage_by_id(
+    user_id: int,
+    period: Period,
+    node_id: int | None = None,
+    group_by_node: bool = False,
+    start: dt | None = Query(None, examples=["2024-01-01T00:00:00+03:30"]),
+    end: dt | None = Query(None, examples=["2024-01-31T23:59:59+03:30"]),
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await user_operator.get_user_usage_by_id(
+        db,
+        user_id=user_id,
         admin=admin,
         start=start,
         end=end,
@@ -492,6 +729,26 @@ async def modify_user_with_template(
     admin: AdminDetails = Depends(get_current),
 ):
     return await user_operator.modify_user_with_template(db, username, modify_template_user, admin)
+
+
+@router.put("/from_template/by-username/{username}", response_model=UserResponse)
+async def modify_user_with_template_by_username(
+    username: str,
+    modify_template_user: ModifyUserByTemplate,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await user_operator.modify_user_with_template(db, username, modify_template_user, admin)
+
+
+@router.put("/from_template/by-id/{user_id}", response_model=UserResponse)
+async def modify_user_with_template_by_id(
+    user_id: int,
+    modify_template_user: ModifyUserByTemplate,
+    db: AsyncSession = Depends(get_db),
+    admin: AdminDetails = Depends(get_current),
+):
+    return await user_operator.modify_user_with_template_by_id(db, user_id, modify_template_user, admin)
 
 
 @router.post("s/bulk/expire", summary="Bulk sum/sub to expire of users", response_description="Success confirmation")

--- a/app/utils/jwt.py
+++ b/app/utils/jwt.py
@@ -44,8 +44,8 @@ async def get_admin_payload(token: str) -> dict | None:
         return
 
 
-async def create_subscription_token(username: str) -> str:
-    data = username + "," + str(ceil(time.time()))
+async def create_subscription_token(user_id: int) -> str:
+    data = "v2," + str(user_id) + "," + str(ceil(time.time()))
     data_b64_str = b64encode(data.encode("utf-8"), altchars=b"-_").decode("utf-8").rstrip("=")
     data_b64_sign = b64encode(
         sha256((data_b64_str + await get_secret_key()).encode("utf-8")).digest(), altchars=b"-_"
@@ -62,8 +62,21 @@ async def get_subscription_payload(token: str) -> dict | None:
         if token.startswith("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."):
             payload = jwt.decode(token, await get_secret_key(), algorithms=["HS256"])
             if payload.get("access") == "subscription":
+                user_id = payload.get("uid")
+                if user_id is not None:
+                    try:
+                        user_id = int(user_id)
+                    except (TypeError, ValueError):
+                        return
+                    return {
+                        "user_id": user_id,
+                        "created_at": datetime.fromtimestamp(payload["iat"], tz=timezone.utc),
+                    }
+                username = payload.get("sub")
+                if not username:
+                    return
                 return {
-                    "username": payload["sub"],
+                    "username": username,
                     "created_at": datetime.fromtimestamp(payload["iat"], tz=timezone.utc),
                 }
             else:
@@ -85,17 +98,29 @@ async def get_subscription_payload(token: str) -> dict | None:
             ).decode("utf-8")[:10]
             if u_signature == u_token_resign:
                 parts = u_token_dec_str.split(",")
-                if len(parts) != 2:
-                    return
-                u_username, u_created_at_str = parts
-                try:
-                    u_created_at = int(u_created_at_str)
-                except ValueError:
-                    return
-                return {
-                    "username": u_username,
-                    "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc),
-                }
+                if len(parts) == 3 and parts[0] == "v2":
+                    _, u_user_id_str, u_created_at_str = parts
+                    try:
+                        u_user_id = int(u_user_id_str)
+                        u_created_at = int(u_created_at_str)
+                    except ValueError:
+                        return
+                    return {
+                        "user_id": u_user_id,
+                        "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc),
+                    }
+
+                if len(parts) == 2:
+                    u_username, u_created_at_str = parts
+                    try:
+                        u_created_at = int(u_created_at_str)
+                    except ValueError:
+                        return
+                    return {
+                        "username": u_username,
+                        "created_at": datetime.fromtimestamp(u_created_at, tz=timezone.utc),
+                    }
+                return
             else:
                 return
     except jwt.exceptions.PyJWTError:

--- a/app/utils/jwt.py
+++ b/app/utils/jwt.py
@@ -62,16 +62,6 @@ async def get_subscription_payload(token: str) -> dict | None:
         if token.startswith("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."):
             payload = jwt.decode(token, await get_secret_key(), algorithms=["HS256"])
             if payload.get("access") == "subscription":
-                user_id = payload.get("uid")
-                if user_id is not None:
-                    try:
-                        user_id = int(user_id)
-                    except (TypeError, ValueError):
-                        return
-                    return {
-                        "user_id": user_id,
-                        "created_at": datetime.fromtimestamp(payload["iat"], tz=timezone.utc),
-                    }
                 username = payload.get("sub")
                 if not username:
                     return

--- a/app/utils/jwt.py
+++ b/app/utils/jwt.py
@@ -18,8 +18,10 @@ async def get_secret_key():
         return key
 
 
-async def create_admin_token(username: str, is_sudo=False) -> str:
+async def create_admin_token(admin_id: int | None, username: str, is_sudo=False) -> str:
     data = {"sub": username, "access": "sudo" if is_sudo else "admin", "iat": datetime.now(timezone.utc)}
+    if admin_id is not None:
+        data["aid"] = int(admin_id)
     if JWT_ACCESS_TOKEN_EXPIRE_MINUTES > 0:
         expire = datetime.now(timezone.utc) + timedelta(minutes=JWT_ACCESS_TOKEN_EXPIRE_MINUTES)
         data["exp"] = expire
@@ -32,6 +34,12 @@ async def get_admin_payload(token: str) -> dict | None:
         payload = jwt.decode(token, await get_secret_key(), algorithms=["HS256"], leeway=5)
         username: str = payload.get("sub")
         access: str = payload.get("access")
+        admin_id = payload.get("aid")
+        if admin_id is not None:
+            try:
+                admin_id = int(admin_id)
+            except (TypeError, ValueError):
+                return
         if not username or access not in ("admin", "sudo"):
             return
         try:
@@ -39,7 +47,12 @@ async def get_admin_payload(token: str) -> dict | None:
         except KeyError:
             created_at = None
 
-        return {"username": username, "is_sudo": access == "sudo", "created_at": created_at}
+        return {
+            "admin_id": admin_id,
+            "username": username,
+            "is_sudo": access == "sudo",
+            "created_at": created_at,
+        }
     except jwt.exceptions.PyJWTError:
         return
 

--- a/cli/admin.py
+++ b/cli/admin.py
@@ -132,14 +132,14 @@ class AdminCLI(BaseCLI):
                 delete_users = typer.confirm(message, default=False)
                 if delete_users:
                     try:
-                        await admin_op.remove_all_users(db, username, SYSTEM_ADMIN)
+                        await admin_op.remove_all_users_by_id(db, target_admin.id, SYSTEM_ADMIN)
                         self.console.print(f"[green]Deleted {user_count} users belonging to admin '{username}'[/green]")
                     except Exception as e:
                         self.console.print(f"[red]Error deleting users: {e}[/red]")
                         return
 
             try:
-                await admin_op.remove_admin(db, username, SYSTEM_ADMIN)
+                await admin_op.remove_admin_by_id(db, target_admin.id, SYSTEM_ADMIN)
                 self.console.print(f"[green]Admin '{username}' deleted successfully[/green]")
             except Exception as e:
                 self.console.print(f"[red]Error deleting admin: {e}[/red]")
@@ -161,7 +161,7 @@ class AdminCLI(BaseCLI):
             return
 
         try:
-            deleted = await admin_op.remove_all_users(db, username, SYSTEM_ADMIN)
+            deleted = await admin_op.remove_all_users_by_id(db, target_admin.id, SYSTEM_ADMIN)
             if deleted == 0:
                 self.console.print(f"[yellow]Admin '{username}' has no users to delete[/yellow]")
             else:
@@ -298,7 +298,7 @@ class AdminCLI(BaseCLI):
                     is_disabled=is_disabled,
                     notification_enable=notification_enable,
                 )
-                await admin_op.modify_admin(db, username, modified_admin, SYSTEM_ADMIN)
+                await admin_op.modify_admin_by_id(db, current_admin.id, modified_admin, SYSTEM_ADMIN)
                 self.console.print(f"[green]Admin '{username}' modified successfully[/green]")
             except Exception as e:
                 self.console.print(f"[red]Error modifying admin: {e}[/red]")
@@ -317,7 +317,8 @@ class AdminCLI(BaseCLI):
 
         if typer.confirm(f"Are you sure you want to reset usage for admin '{username}'?"):
             try:
-                await admin_op.reset_admin_usage(db, username, SYSTEM_ADMIN)
+                target_admin = next(admin for admin in admins if admin.username == username)
+                await admin_op.reset_admin_usage_by_id(db, target_admin.id, SYSTEM_ADMIN)
                 self.console.print(f"[green]Usage reset for admin '{username}'[/green]")
             except Exception as e:
                 self.console.print(f"[red]Error resetting usage: {e}[/red]")

--- a/dashboard/src/components/admins/admins-table.tsx
+++ b/dashboard/src/components/admins/admins-table.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { AdminDetails } from '@/service/api'
 import {
-  useActivateAllDisabledUsers,
+  useActivateAllDisabledUsersById,
   useBulkActivateAllDisabledUsers,
   useBulkDeleteAdmins,
   useBulkDisableAdmins,
@@ -9,9 +9,9 @@ import {
   useBulkEnableAdmins,
   useBulkRemoveAllUsers,
   useBulkResetAdminsUsage,
-  useDisableAllActiveUsers,
   useGetAdmins,
-  useRemoveAllUsers,
+  useDisableAllActiveUsersById,
+  useRemoveAllUsersById,
 } from '@/service/api'
 import { DataTable } from './data-table'
 import { setupColumns } from './columns'
@@ -41,7 +41,7 @@ interface AdminsTableProps {
   onEdit: (admin: AdminDetails) => void
   onDelete: (admin: AdminDetails) => void
   onToggleStatus: (admin: AdminDetails, checked: boolean) => void
-  onResetUsage: (adminUsername: string) => void
+  onResetUsage: (admin: AdminDetails) => void
   onTotalAdminsChange?: (counts: { total: number; active: number; disabled: number } | null) => void
 }
 
@@ -217,9 +217,9 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
   const [bulkAction, setBulkAction] = useState<BulkAdminActionType | null>(null)
   const [adminToDelete, setAdminToDelete] = useState<AdminDetails | null>(null)
   const [adminToToggleStatus, setAdminToToggleStatus] = useState<AdminDetails | null>(null)
-  const [adminToReset, setAdminToReset] = useState<string | null>(null)
-  const [bulkUsersStatusAction, setBulkUsersStatusAction] = useState<{ username: string; actionType: BulkUsersActionType } | null>(null)
-  const [adminToRemoveAllUsers, setAdminToRemoveAllUsers] = useState<string | null>(null)
+  const [adminToReset, setAdminToReset] = useState<AdminDetails | null>(null)
+  const [bulkUsersStatusAction, setBulkUsersStatusAction] = useState<{ admin: AdminDetails; actionType: BulkUsersActionType } | null>(null)
+  const [adminToRemoveAllUsers, setAdminToRemoveAllUsers] = useState<AdminDetails | null>(null)
   const bulkDeleteAdminsMutation = useBulkDeleteAdmins()
   const bulkResetAdminsUsageMutation = useBulkResetAdminsUsage()
   const bulkDisableAdminsMutation = useBulkDisableAdmins()
@@ -260,9 +260,26 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
       }
     }
   }, [adminsResponse, onTotalAdminsChange])
-  const disableAllActiveUsersMutation = useDisableAllActiveUsers()
-  const activateAllDisabledUsersMutation = useActivateAllDisabledUsers()
-  const removeAllUsersMutation = useRemoveAllUsers()
+  const disableAllActiveUsersMutation = useDisableAllActiveUsersById()
+  const activateAllDisabledUsersMutation = useActivateAllDisabledUsersById()
+  const removeAllUsersMutation = useRemoveAllUsersById()
+
+  const getAdminId = useCallback(
+    (admin: AdminDetails) => {
+      if (admin.id == null) {
+        toast.error(t('error', { defaultValue: 'Error' }), {
+          description: t('admins.missingId', {
+            name: admin.username,
+            defaultValue: 'Admin "{name}" is missing an id in the current response.',
+          }),
+        })
+        return null
+      }
+
+      return admin.id
+    },
+    [t],
+  )
 
   // Update filters when pagination changes
   useEffect(() => {
@@ -330,8 +347,8 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
     setStatusToggleDialogOpen(true)
   }
 
-  const handleResetUsersUsageClick = (adminUsername: string) => {
-    setAdminToReset(adminUsername)
+  const handleResetUsersUsageClick = (admin: AdminDetails) => {
+    setAdminToReset(admin)
     setResetUsersUsageDialogOpen(true)
   }
   const handleConfirmResetUsersUsage = async () => {
@@ -342,18 +359,18 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
     }
   }
 
-  const handleRemoveAllUsersClick = (adminUsername: string) => {
-    setAdminToRemoveAllUsers(adminUsername)
+  const handleRemoveAllUsersClick = (admin: AdminDetails) => {
+    setAdminToRemoveAllUsers(admin)
     setRemoveAllUsersDialogOpen(true)
   }
 
-  const handleDisableAllActiveUsersClick = (adminUsername: string) => {
-    setBulkUsersStatusAction({ username: adminUsername, actionType: 'disable' })
+  const handleDisableAllActiveUsersClick = (admin: AdminDetails) => {
+    setBulkUsersStatusAction({ admin, actionType: 'disable' })
     setBulkUsersStatusDialogOpen(true)
   }
 
-  const handleActivateAllDisabledUsersClick = (adminUsername: string) => {
-    setBulkUsersStatusAction({ username: adminUsername, actionType: 'activate' })
+  const handleActivateAllDisabledUsersClick = (admin: AdminDetails) => {
+    setBulkUsersStatusAction({ admin, actionType: 'activate' })
     setBulkUsersStatusDialogOpen(true)
   }
 
@@ -365,28 +382,35 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
   const handleConfirmBulkUsersStatusAction = async () => {
     if (!bulkUsersStatusAction) return
 
-    const { username, actionType } = bulkUsersStatusAction
+    const { admin, actionType } = bulkUsersStatusAction
+    const adminId = getAdminId(admin)
+    if (adminId == null) return
 
     try {
       if (actionType === 'disable') {
-        await disableAllActiveUsersMutation.mutateAsync({ username })
+        await disableAllActiveUsersMutation.mutateAsync({ adminId })
       } else {
-        await activateAllDisabledUsersMutation.mutateAsync({ username })
+        await activateAllDisabledUsersMutation.mutateAsync({ adminId })
       }
 
       toast.success(t('success', { defaultValue: 'Success' }), {
         description: t(actionType === 'disable' ? 'admins.disableAllActiveUsersSuccess' : 'admins.activateAllDisabledUsersSuccess', {
-          name: username,
+          name: admin.username,
           defaultValue:
-            actionType === 'disable' ? `All active users under admin "${username}" have been disabled successfully` : `All disabled users under admin "${username}" have been activated successfully`,
+            actionType === 'disable'
+              ? `All active users under admin "${admin.username}" have been disabled successfully`
+              : `All disabled users under admin "${admin.username}" have been activated successfully`,
         }),
       })
       closeBulkUsersStatusDialog()
     } catch (error) {
       toast.error(t('error', { defaultValue: 'Error' }), {
         description: t(actionType === 'disable' ? 'admins.disableAllActiveUsersFailed' : 'admins.activateAllDisabledUsersFailed', {
-          name: username,
-          defaultValue: actionType === 'disable' ? `Failed to disable all active users under admin "${username}"` : `Failed to activate all disabled users under admin "${username}"`,
+          name: admin.username,
+          defaultValue:
+            actionType === 'disable'
+              ? `Failed to disable all active users under admin "${admin.username}"`
+              : `Failed to activate all disabled users under admin "${admin.username}"`,
         }),
       })
     }
@@ -394,23 +418,26 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
 
   const handleConfirmRemoveAllUsers = async () => {
     if (adminToRemoveAllUsers) {
+      const adminId = getAdminId(adminToRemoveAllUsers)
+      if (adminId == null) return
+
       try {
         await removeAllUsersMutation.mutateAsync({
-          username: adminToRemoveAllUsers,
+          adminId,
         })
         toast.success(t('success', { defaultValue: 'Success' }), {
           description: t('admins.removeAllUsersSuccess', {
-            name: adminToRemoveAllUsers,
+            name: adminToRemoveAllUsers.username,
             defaultValue: `All users under admin "{name}" have been removed successfully`,
           }),
         })
-        patchAdminInAdminsCache(queryClient, adminToRemoveAllUsers, { total_users: 0 })
+        patchAdminInAdminsCache(queryClient, adminId, { total_users: 0 })
         setRemoveAllUsersDialogOpen(false)
         setAdminToRemoveAllUsers(null)
       } catch (error) {
         toast.error(t('error', { defaultValue: 'Error' }), {
           description: t('admins.removeAllUsersFailed', {
-            name: adminToRemoveAllUsers,
+            name: adminToRemoveAllUsers.username,
             defaultValue: `Failed to remove all users under admin "{name}"`,
           }),
         })
@@ -849,7 +876,7 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
       )}
       {adminToReset && (
         <ResetUsersUsageConfirmationDialog
-          adminUsername={adminToReset}
+          adminUsername={adminToReset.username}
           onConfirm={handleConfirmResetUsersUsage}
           isOpen={resetUsersUsageDialogOpen}
           onClose={() => setResetUsersUsageDialogOpen(false)}
@@ -857,7 +884,7 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
       )}
       {bulkUsersStatusAction && (
         <BulkUsersStatusConfirmationDialog
-          adminUsername={bulkUsersStatusAction.username}
+          adminUsername={bulkUsersStatusAction.admin.username}
           actionType={bulkUsersStatusAction.actionType}
           onConfirm={handleConfirmBulkUsersStatusAction}
           isOpen={bulkUsersStatusDialogOpen}
@@ -866,7 +893,7 @@ export default function AdminsTable({ onEdit, onDelete, onToggleStatus, onResetU
       )}
       {adminToRemoveAllUsers && (
         <RemoveAllUsersConfirmationDialog
-          adminUsername={adminToRemoveAllUsers}
+          adminUsername={adminToRemoveAllUsers.username}
           onConfirm={handleConfirmRemoveAllUsers}
           isOpen={removeAllUsersDialogOpen}
           onClose={() => setRemoveAllUsersDialogOpen(false)}

--- a/dashboard/src/components/admins/columns.tsx
+++ b/dashboard/src/components/admins/columns.tsx
@@ -16,10 +16,10 @@ interface ColumnSetupProps {
   onEdit: (admin: AdminDetails) => void
   onDelete: (admin: AdminDetails) => void
   toggleStatus: (admin: AdminDetails) => void
-  onResetUsage: (adminUsername: string) => void
-  onDisableAllActiveUsers: (adminUsername: string) => void
-  onActivateAllDisabledUsers: (adminUsername: string) => void
-  onRemoveAllUsers: (adminUsername: string) => void
+  onResetUsage: (admin: AdminDetails) => void
+  onDisableAllActiveUsers: (admin: AdminDetails) => void
+  onActivateAllDisabledUsers: (admin: AdminDetails) => void
+  onRemoveAllUsers: (admin: AdminDetails) => void
 }
 
 const createSortButton = (
@@ -206,7 +206,7 @@ export const setupColumns = ({
                   onSelect={e => {
                     e.preventDefault()
                     e.stopPropagation()
-                    onResetUsage(row.original.username)
+                    onResetUsage(row.original)
                   }}
                 >
                   <RefreshCw className="mr-2 h-4 w-4" />
@@ -229,7 +229,7 @@ export const setupColumns = ({
                     onSelect={e => {
                       e.preventDefault()
                       e.stopPropagation()
-                      onDisableAllActiveUsers(row.original.username)
+                      onDisableAllActiveUsers(row.original)
                     }}
                   >
                     <UserMinus className="mr-2 h-4 w-4" />
@@ -241,7 +241,7 @@ export const setupColumns = ({
                     onSelect={e => {
                       e.preventDefault()
                       e.stopPropagation()
-                      onActivateAllDisabledUsers(row.original.username)
+                      onActivateAllDisabledUsers(row.original)
                     }}
                   >
                     <UserCheck className="mr-2 h-4 w-4" />
@@ -254,7 +254,7 @@ export const setupColumns = ({
                     onSelect={e => {
                       e.preventDefault()
                       e.stopPropagation()
-                      onRemoveAllUsers(row.original.username)
+                      onRemoveAllUsers(row.original)
                     }}
                   >
                     <UserX className="mr-2 h-4 w-4" />

--- a/dashboard/src/components/admins/data-table.tsx
+++ b/dashboard/src/components/admins/data-table.tsx
@@ -18,10 +18,10 @@ interface DataTableProps<TData extends AdminDetails> {
   onDelete: (admin: AdminDetails) => void
   onToggleStatus: (admin: AdminDetails) => void
   setStatusToggleDialogOpen: (isOpen: boolean) => void
-  onResetUsage: (adminUsername: string) => void
-  onDisableAllActiveUsers?: (adminUsername: string) => void
-  onActivateAllDisabledUsers?: (adminUsername: string) => void
-  onRemoveAllUsers?: (adminUsername: string) => void
+  onResetUsage: (admin: AdminDetails) => void
+  onDisableAllActiveUsers?: (admin: AdminDetails) => void
+  onActivateAllDisabledUsers?: (admin: AdminDetails) => void
+  onRemoveAllUsers?: (admin: AdminDetails) => void
   onSelectionChange?: (selectedUsernames: string[]) => void
   resetSelectionKey?: number
   isLoading?: boolean
@@ -44,10 +44,10 @@ const ExpandedRowContent = memo(
     onEdit: (admin: AdminDetails) => void
     onDelete: (admin: AdminDetails) => void
     onToggleStatus: (admin: AdminDetails) => void
-    onResetUsage: (adminUsername: string) => void
-    onDisableAllActiveUsers?: (adminUsername: string) => void
-    onActivateAllDisabledUsers?: (adminUsername: string) => void
-    onRemoveAllUsers?: (adminUsername: string) => void
+    onResetUsage: (admin: AdminDetails) => void
+    onDisableAllActiveUsers?: (admin: AdminDetails) => void
+    onActivateAllDisabledUsers?: (admin: AdminDetails) => void
+    onRemoveAllUsers?: (admin: AdminDetails) => void
     currentAdminUsername?: string
   }) => {
     const { t } = useTranslation()
@@ -96,7 +96,7 @@ const ExpandedRowContent = memo(
                 onSelect={e => {
                   e.preventDefault()
                   e.stopPropagation()
-                  onResetUsage(row.username)
+                  onResetUsage(row)
                 }}
               >
                 <RefreshCw className="mr-2 h-4 w-4" />
@@ -107,7 +107,7 @@ const ExpandedRowContent = memo(
                   onSelect={e => {
                     e.preventDefault()
                     e.stopPropagation()
-                    onDisableAllActiveUsers(row.username)
+                    onDisableAllActiveUsers(row)
                   }}
                 >
                   <UserMinus className="mr-2 h-4 w-4" />
@@ -119,7 +119,7 @@ const ExpandedRowContent = memo(
                   onSelect={e => {
                     e.preventDefault()
                     e.stopPropagation()
-                    onActivateAllDisabledUsers(row.username)
+                    onActivateAllDisabledUsers(row)
                   }}
                 >
                   <UserCheck className="mr-2 h-4 w-4" />
@@ -132,7 +132,7 @@ const ExpandedRowContent = memo(
                   onSelect={e => {
                     e.preventDefault()
                     e.stopPropagation()
-                    onRemoveAllUsers(row.username)
+                    onRemoveAllUsers(row)
                   }}
                 >
                   <UserX className="mr-2 h-4 w-4" />

--- a/dashboard/src/components/admins/filters.tsx
+++ b/dashboard/src/components/admins/filters.tsx
@@ -61,6 +61,7 @@ export function Filters<T extends BaseFilters>({ filters, onFilterChange, handle
   const dir = useDirDetection()
   const [search, setSearch] = useState(filters.username || '')
   const onFilterChangeRef = useRef(onFilterChange)
+  const compactActionButtonClass = 'relative flex h-9 w-9 items-center justify-center border md:h-10 md:w-10'
 
   // Keep the ref in sync with the prop
   onFilterChangeRef.current = onFilterChange
@@ -140,7 +141,7 @@ export function Filters<T extends BaseFilters>({ filters, onFilterChange, handle
                 type="button"
                 size="icon-md"
                 variant="ghost"
-                className="relative flex h-9 w-9 items-center justify-center border md:h-10 md:w-10"
+                className={compactActionButtonClass}
                 aria-label={t('sortOptions', { defaultValue: 'Sort Options' })}
               >
                 <ArrowUpDown className="h-4 w-4" />
@@ -180,7 +181,7 @@ export function Filters<T extends BaseFilters>({ filters, onFilterChange, handle
 
       {/* Refresh Button */}
       <div className="flex h-full flex-shrink-0 items-center gap-0">
-        <Button type="button" size="icon-md" onClick={handleRefreshClick} variant="ghost" className="flex items-center gap-2 border">
+        <Button type="button" size="icon-md" onClick={handleRefreshClick} variant="ghost" className={compactActionButtonClass}>
           <RefreshCw className="h-4 w-4" />
         </Button>
       </div>

--- a/dashboard/src/components/charts/all-nodes-stacked-bar-chart.tsx
+++ b/dashboard/src/components/charts/all-nodes-stacked-bar-chart.tsx
@@ -6,7 +6,7 @@ import { type ChartConfig, ChartContainer, ChartTooltip } from '@/components/ui/
 import { useTranslation } from 'react-i18next'
 import useDirDetection from '@/hooks/use-dir-detection'
 import { useChartViewType } from '@/hooks/use-chart-view-type'
-import { Period, type NodeUsageStat, type UserUsageStat, useGetAdminUsage, useGetNodesSimple, type NodeSimple, useGetUsage } from '@/service/api'
+import { Period, type NodeUsageStat, type UserUsageStat, useGetAdminUsageById, useGetAdminUsageByUsername, useGetNodesSimple, type NodeSimple, useGetUsage } from '@/service/api'
 import { formatBytes, formatGigabytes } from '@/utils/formatByte'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from './empty-state'
@@ -183,6 +183,7 @@ function NodePieTooltip({ active, payload }: TooltipProps<number, string>) {
 export function AllNodesStackedBarChart() {
   const [chartView, setChartView] = useState<'bar' | 'pie'>('bar')
   const [selectedAdmin, setSelectedAdmin] = useState<string>('all')
+  const [selectedAdminId, setSelectedAdminId] = useState<number | null>(null)
   const [selectedTime, setSelectedTime] = useState<TrafficShortcutKey>('1w')
   const [showCustomRange, setShowCustomRange] = useState(false)
   const [customRange, setCustomRange] = useState<DateRange | undefined>(undefined)
@@ -263,16 +264,23 @@ export function AllNodesStackedBarChart() {
     },
   })
 
-  const { data: adminUsageData, isLoading: isLoadingAdminUsage, error: adminUsageError } = useGetAdminUsage(selectedAdmin, usageParams, {
+  const { data: adminUsageByIdData, isLoading: isLoadingAdminUsageById, error: adminUsageByIdError } = useGetAdminUsageById(selectedAdminId ?? 0, usageParams, {
     query: {
-      enabled: !shouldUseNodeUsage && selectedAdmin !== 'all',
+      enabled: !shouldUseNodeUsage && selectedAdmin !== 'all' && selectedAdminId != null,
       refetchInterval: 1000 * 60 * 5,
     },
   })
 
-  const usageData = shouldUseNodeUsage ? nodeUsageData : adminUsageData
-  const isLoading = shouldUseNodeUsage ? isLoadingNodesUsage : isLoadingAdminUsage
-  const error = shouldUseNodeUsage ? nodesUsageError : adminUsageError
+  const { data: adminUsageByUsernameData, isLoading: isLoadingAdminUsageByUsername, error: adminUsageByUsernameError } = useGetAdminUsageByUsername(selectedAdmin, usageParams, {
+    query: {
+      enabled: !shouldUseNodeUsage && selectedAdmin !== 'all' && selectedAdminId == null,
+      refetchInterval: 1000 * 60 * 5,
+    },
+  })
+
+  const usageData = shouldUseNodeUsage ? nodeUsageData : selectedAdminId != null ? adminUsageByIdData : adminUsageByUsernameData
+  const isLoading = shouldUseNodeUsage ? isLoadingNodesUsage : selectedAdminId != null ? isLoadingAdminUsageById : isLoadingAdminUsageByUsername
+  const error = shouldUseNodeUsage ? nodesUsageError : selectedAdminId != null ? adminUsageByIdError : adminUsageByUsernameError
   const statsByNode = useMemo(() => toStatsRecord<NodeUsageStat | UserUsageStat>(usageData?.stats), [usageData?.stats])
 
   const { chartData, totalUsage } = useMemo(() => {
@@ -493,7 +501,15 @@ export function AllNodesStackedBarChart() {
                 </button>
               </div>
               <div className="flex w-full items-center gap-2 sm:w-auto sm:shrink-0">
-                <AdminFilterCombobox value={selectedAdmin} onValueChange={setSelectedAdmin} className="min-w-0 flex-1 sm:w-[220px] sm:flex-none" />
+                <AdminFilterCombobox
+                  value={selectedAdmin}
+                  onValueChange={username => {
+                    setSelectedAdmin(username)
+                    setSelectedAdminId(null)
+                  }}
+                  onAdminSelect={admin => setSelectedAdminId(admin?.id ?? null)}
+                  className="min-w-0 flex-1 sm:w-[220px] sm:flex-none"
+                />
                 <div className="inline-flex h-8 shrink-0 items-center gap-1 rounded-md border bg-muted/30 p-1">
                   <button
                     type="button"

--- a/dashboard/src/components/charts/costume-bar-chart.tsx
+++ b/dashboard/src/components/charts/costume-bar-chart.tsx
@@ -6,7 +6,7 @@ import { type ChartConfig, ChartContainer, ChartTooltip } from '@/components/ui/
 import { useTranslation } from 'react-i18next'
 import useDirDetection from '@/hooks/use-dir-detection'
 import { useChartViewType } from '@/hooks/use-chart-view-type'
-import { Period, type NodeUsageStat, type UserUsageStat, useGetAdminUsage, useGetUsage } from '@/service/api'
+import { Period, type NodeUsageStat, type UserUsageStat, useGetAdminUsageById, useGetAdminUsageByUsername, useGetUsage } from '@/service/api'
 import { formatBytes } from '@/utils/formatByte'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from './empty-state'
@@ -109,6 +109,7 @@ function CustomBarTooltip({ active, payload, period }: TooltipProps<number, stri
 
 export function CostumeBarChart({ nodeId }: CostumeBarChartProps) {
   const [selectedAdmin, setSelectedAdmin] = useState<string>('all')
+  const [selectedAdminId, setSelectedAdminId] = useState<number | null>(null)
   const [selectedTime, setSelectedTime] = useState<TrafficShortcutKey>('1w')
   const [showCustomRange, setShowCustomRange] = useState(false)
   const [customRange, setCustomRange] = useState<DateRange | undefined>(undefined)
@@ -156,16 +157,23 @@ export function CostumeBarChart({ nodeId }: CostumeBarChartProps) {
     },
   })
 
-  const { data: adminUsageData, isLoading: isLoadingAdminUsage, error: adminUsageError } = useGetAdminUsage(selectedAdmin, adminUsageParams, {
+  const { data: adminUsageByIdData, isLoading: isLoadingAdminUsageById, error: adminUsageByIdError } = useGetAdminUsageById(selectedAdminId ?? 0, adminUsageParams, {
     query: {
-      enabled: !shouldUseNodeUsage && selectedAdmin !== 'all',
+      enabled: !shouldUseNodeUsage && selectedAdmin !== 'all' && selectedAdminId != null,
       refetchInterval: 1000 * 60 * 5,
     },
   })
 
-  const usageData = shouldUseNodeUsage ? nodeUsageData : adminUsageData
-  const isLoading = shouldUseNodeUsage ? isLoadingNodeUsage : isLoadingAdminUsage
-  const error = shouldUseNodeUsage ? nodeUsageError : adminUsageError
+  const { data: adminUsageByUsernameData, isLoading: isLoadingAdminUsageByUsername, error: adminUsageByUsernameError } = useGetAdminUsageByUsername(selectedAdmin, adminUsageParams, {
+    query: {
+      enabled: !shouldUseNodeUsage && selectedAdmin !== 'all' && selectedAdminId == null,
+      refetchInterval: 1000 * 60 * 5,
+    },
+  })
+
+  const usageData = shouldUseNodeUsage ? nodeUsageData : selectedAdminId != null ? adminUsageByIdData : adminUsageByUsernameData
+  const isLoading = shouldUseNodeUsage ? isLoadingNodeUsage : selectedAdminId != null ? isLoadingAdminUsageById : isLoadingAdminUsageByUsername
+  const error = shouldUseNodeUsage ? nodeUsageError : selectedAdminId != null ? adminUsageByIdError : adminUsageByUsernameError
 
   const statsArr = useMemo(
     () => pickStatsArray<NodeUsageStat | UserUsageStat>(usageData?.stats, nodeId !== undefined ? [String(nodeId), '-1'] : ['-1']),
@@ -272,7 +280,15 @@ export function CostumeBarChart({ nodeId }: CostumeBarChartProps) {
                 <Calendar className="h-4 w-4" />
               </button>
             </div>
-            <AdminFilterCombobox value={selectedAdmin} onValueChange={setSelectedAdmin} className="w-full sm:w-[220px] sm:shrink-0" />
+            <AdminFilterCombobox
+              value={selectedAdmin}
+              onValueChange={username => {
+                setSelectedAdmin(username)
+                setSelectedAdminId(null)
+              }}
+              onAdminSelect={admin => setSelectedAdminId(admin?.id ?? null)}
+              className="w-full sm:w-[220px] sm:shrink-0"
+            />
           </div>
           {showCustomRange && (
             <div className="flex w-full">

--- a/dashboard/src/components/dashboard/admin-statistics-card.tsx
+++ b/dashboard/src/components/dashboard/admin-statistics-card.tsx
@@ -61,8 +61,8 @@ const AdminStatisticsCard = ({
   // Use admin-specific stats if available, otherwise fall back to global stats
   const statsToUse = adminSystemStats || systemStats
 
-  // For DataUsageChart: pass admin_username for specific admin data, except for 'Total' which shows global data
-  const shouldPassAdminUsername = admin.username !== 'Total'
+  // For DataUsageChart: prefer admin id for specific admin data, except for 'Total' which shows global data.
+  const shouldScopeAdminData = admin.username !== 'Total'
 
   if (showAdminInfo)
     return (
@@ -81,7 +81,7 @@ const AdminStatisticsCard = ({
         </div>
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           <UserStatisticsCard data={statsToUse} />
-          <DeferredDataUsageChart admin_username={shouldPassAdminUsername ? admin.username : undefined} />
+          <DeferredDataUsageChart adminId={shouldScopeAdminData ? admin.id ?? undefined : undefined} adminUsername={shouldScopeAdminData ? admin.username : undefined} />
         </div>
       </div>
     )
@@ -89,7 +89,7 @@ const AdminStatisticsCard = ({
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
       <UserStatisticsCard data={statsToUse} />
-      <DeferredDataUsageChart admin_username={shouldPassAdminUsername ? admin.username : undefined} />
+      <DeferredDataUsageChart adminId={shouldScopeAdminData ? admin.id ?? undefined : undefined} adminUsername={shouldScopeAdminData ? admin.username : undefined} />
     </div>
   )
 }

--- a/dashboard/src/components/dashboard/data-usage-chart.tsx
+++ b/dashboard/src/components/dashboard/data-usage-chart.tsx
@@ -105,7 +105,7 @@ function CustomBarTooltip({ active, payload, period }: CustomBarTooltipProps) {
   )
 }
 
-const DataUsageChart = ({ admin_username }: { admin_username?: string }) => {
+const DataUsageChart = ({ adminId, adminUsername }: { adminId?: number; adminUsername?: string }) => {
   const { t, i18n } = useTranslation()
   const { admin } = useAdmin()
   const dir = useDirDetection()
@@ -139,7 +139,7 @@ const DataUsageChart = ({ admin_username }: { admin_username?: string }) => {
   const queryRange = useMemo(() => getChartQueryRangeFromShortcut(periodOption.value, new Date(), { minuteForOneHour: true }), [periodOption.value])
   const activePeriod = queryRange.period
 
-  const shouldUseNodeUsage = is_sudo && !admin_username
+  const shouldUseNodeUsage = is_sudo && adminId == null && !adminUsername
 
   const nodeUsageParams = useMemo(
     () => ({
@@ -152,12 +152,12 @@ const DataUsageChart = ({ admin_username }: { admin_username?: string }) => {
 
   const userUsageParams = useMemo(
     () => ({
-      ...(admin_username ? { admin: [admin_username] } : {}),
+      ...(adminId != null ? { admin_id: adminId } : adminUsername ? { admin: [adminUsername] } : {}),
       period: activePeriod,
       start: queryRange.startDate,
       end: queryRange.endDate,
     }),
-    [admin_username, activePeriod, queryRange.startDate, queryRange.endDate],
+    [adminId, adminUsername, activePeriod, queryRange.startDate, queryRange.endDate],
   )
 
   const { data: nodeData, isLoading: isLoadingNodes } = useGetUsage(nodeUsageParams, {

--- a/dashboard/src/components/dialogs/admin-modal.tsx
+++ b/dashboard/src/components/dialogs/admin-modal.tsx
@@ -12,7 +12,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { VariablesPopover } from '@/components/ui/variables-popover'
 import useDynamicErrorHandler from '@/hooks/use-dynamic-errors.ts'
 import { cn } from '@/lib/utils'
-import { useCreateAdmin, useModifyAdmin } from '@/service/api'
+import { useCreateAdmin, useModifyAdminById } from '@/service/api'
 import { upsertAdminInAdminsCache } from '@/utils/adminsCache'
 import { useQueryClient } from '@tanstack/react-query'
 import { ChevronDown, Pencil, UserCog } from 'lucide-react'
@@ -25,16 +25,17 @@ interface AdminModalProps {
   isDialogOpen: boolean
   onOpenChange: (open: boolean) => void
   editingAdmin?: boolean
+  editingAdminId?: number
   editingAdminUserName: string
   form: UseFormReturn<AdminFormValuesInput>
 }
 
-export default function AdminModal({ isDialogOpen, onOpenChange, editingAdminUserName, editingAdmin, form }: AdminModalProps) {
+export default function AdminModal({ isDialogOpen, onOpenChange, editingAdminId, editingAdminUserName, editingAdmin, form }: AdminModalProps) {
   const { t } = useTranslation()
   const handleError = useDynamicErrorHandler()
   const queryClient = useQueryClient()
   const addAdminMutation = useCreateAdmin()
-  const modifyAdminMutation = useModifyAdmin()
+  const modifyAdminMutation = useModifyAdminById()
 
   useEffect(() => {
     if (!isDialogOpen) setNotificationExpanded(false)
@@ -70,9 +71,9 @@ export default function AdminModal({ isDialogOpen, onOpenChange, editingAdminUse
         discord_id: values.discord_id,
         notification_enable: values.notification_enable || null,
       }
-      if (editingAdmin && editingAdminUserName) {
+      if (editingAdmin && editingAdminId != null) {
         const updatedAdmin = await modifyAdminMutation.mutateAsync({
-          username: editingAdminUserName,
+          adminId: editingAdminId,
           data: editData,
         })
         upsertAdminInAdminsCache(queryClient, updatedAdmin, { allowInsert: true })

--- a/dashboard/src/components/dialogs/set-owner-modal.tsx
+++ b/dashboard/src/components/dialogs/set-owner-modal.tsx
@@ -4,13 +4,14 @@ import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Loader2, UserCheck } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useSetOwner, useBulkSetOwner, UserResponse } from '@/service/api'
+import { useBulkSetOwner, useSetOwnerById, UserResponse } from '@/service/api'
 import { toast } from 'sonner'
 import useDynamicErrorHandler from '@/hooks/use-dynamic-errors'
 
 interface SetOwnerModalProps {
   open: boolean
   onClose: () => void
+  userId?: number
   username?: string
   userIds?: number[]
   selectedCount?: number
@@ -18,7 +19,7 @@ interface SetOwnerModalProps {
   onSuccess?: (user?: UserResponse) => void
 }
 
-export default function SetOwnerModal({ open, onClose, username, userIds, selectedCount, currentOwner, onSuccess }: SetOwnerModalProps) {
+export default function SetOwnerModal({ open, onClose, userId, username, userIds, selectedCount, currentOwner, onSuccess }: SetOwnerModalProps) {
   const { t } = useTranslation()
   const [selectedAdmin, setSelectedAdmin] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
@@ -28,7 +29,7 @@ export default function SetOwnerModal({ open, onClose, username, userIds, select
   const [isError, setIsError] = useState(false)
   const isBulkMode = Boolean(userIds?.length)
   const bulkCount = selectedCount ?? userIds?.length ?? 0
-  const setOwnerMutation = useSetOwner({
+  const setOwnerMutation = useSetOwnerById({
     mutation: {
       onSuccess: updatedUser => {
         if (onSuccess && updatedUser) {
@@ -84,8 +85,8 @@ export default function SetOwnerModal({ open, onClose, username, userIds, select
         })
         toast.success(t('setOwnerModal.bulkSuccess', { count: bulkCount, admin: selectedAdmin }))
         onSuccess?.()
-      } else if (username) {
-        await setOwnerMutation.mutateAsync({ username, params: { admin_username: selectedAdmin } })
+      } else if (userId) {
+        await setOwnerMutation.mutateAsync({ userId, params: { admin_username: selectedAdmin } })
         toast.success(t('setOwnerModal.success', { username, admin: selectedAdmin }))
       }
       onClose()

--- a/dashboard/src/components/dialogs/usage-modal.tsx
+++ b/dashboard/src/components/dialogs/usage-modal.tsx
@@ -5,7 +5,7 @@ import { ChartContainer, ChartTooltip, ChartConfig } from '../ui/chart'
 import { BarChart3, PieChart as PieChartIcon, TrendingUp, Calendar, Info } from 'lucide-react'
 import TimeSelector, { TRAFFIC_TIME_SELECTOR_SHORTCUTS } from '../charts/time-selector'
 import { useTranslation } from 'react-i18next'
-import { Period, useGetUserUsage, useGetNodesSimple, useGetCurrentAdmin, NodeSimple, GetUserUsageParams } from '@/service/api'
+import { Period, useGetNodesSimple, useGetCurrentAdmin, useGetUserUsageById, NodeSimple, GetUserUsageParams } from '@/service/api'
 import { DateRange } from 'react-day-picker'
 import { TimeRangeSelector } from '@/components/common/time-range-selector'
 import { Button } from '../ui/button'
@@ -27,7 +27,7 @@ import {
 interface UsageModalProps {
   open: boolean
   onClose: () => void
-  username: string
+  userId: number
 }
 
 type NodePieChartDataPoint = {
@@ -175,7 +175,7 @@ function NodePieTooltip({ active, payload }: TooltipProps<number, string>) {
   )
 }
 
-const UsageModal = ({ open, onClose, username }: UsageModalProps) => {
+const UsageModal = ({ open, onClose, userId }: UsageModalProps) => {
   // Memoize now only once per modal open
   const nowRef = useRef<number>(Date.now())
   useEffect(() => {
@@ -324,7 +324,7 @@ const UsageModal = ({ open, onClose, username }: UsageModalProps) => {
   }, [backendPeriod, queryRange.startDate, queryRange.endDate, selectedNodeId, is_sudo])
 
   // Only fetch when modal is open
-  const { data, isLoading } = useGetUserUsage(username, userUsageParams, { query: { enabled: open } })
+  const { data, isLoading } = useGetUserUsageById(userId, userUsageParams, { query: { enabled: open && !!userId } })
 
   // Prepare chart data for BarChart with node grouping
   const processedChartData = useMemo(() => {

--- a/dashboard/src/components/dialogs/user-modal.tsx
+++ b/dashboard/src/components/dialogs/user-modal.tsx
@@ -28,10 +28,10 @@ import {
   useCreateUserFromTemplate,
   useGetGroupsSimple,
   useGetUserTemplatesSimple,
-  useModifyUser,
-  useModifyUserWithTemplate,
-  useResetUserDataUsage,
-  useRevokeUserSubscription,
+  useModifyUserById,
+  useModifyUserWithTemplateById,
+  useResetUserDataUsageById,
+  useRevokeUserSubscriptionById,
   type UserResponse,
 } from '@/service/api'
 import { dateUtils, useRelativeExpiryDate } from '@/utils/dateFormatter'
@@ -546,7 +546,7 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
       onSuccess: data => syncUserCacheFromApiResponse(data, { allowInsert: true, notifySuccessCallback: true }),
     },
   })
-  const modifyUserMutation = useModifyUser({
+  const modifyUserMutation = useModifyUserById({
     mutation: {
       onSuccess: data => syncUserCacheFromApiResponse(data, { allowInsert: true, notifySuccessCallback: true }),
     },
@@ -558,12 +558,12 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
   })
 
   // Add the mutation hook at the top with other mutations
-  const modifyUserWithTemplateMutation = useModifyUserWithTemplate({
+  const modifyUserWithTemplateMutation = useModifyUserWithTemplateById({
     mutation: {
       onSuccess: data => syncUserCacheFromApiResponse(data, { allowInsert: true, notifySuccessCallback: true }),
     },
   })
-  const resetUserDataUsageMutation = useResetUserDataUsage({
+  const resetUserDataUsageMutation = useResetUserDataUsageById({
     mutation: {
       onSuccess: updatedUser => {
         if (updatedUser) {
@@ -572,7 +572,7 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
       },
     },
   })
-  const revokeUserSubscriptionMutation = useRevokeUserSubscription({
+  const revokeUserSubscriptionMutation = useRevokeUserSubscriptionById({
     mutation: {
       onSuccess: updatedUser => {
         if (updatedUser) {
@@ -884,6 +884,7 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
   const handleTemplateMutation = React.useCallback(
     async (values: UseFormValues | UseEditFormValues) => {
       if (!selectedTemplateId) return
+      if (editingUser && !editingUserId) return
 
       // Validate template mode requirements
       if (!values.username || values.username.length < 3) {
@@ -893,9 +894,9 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
 
       setLoading(true)
       try {
-        if (editingUser) {
+        if (editingUser && editingUserId) {
           await modifyUserWithTemplateMutation.mutateAsync({
-            username: values.username,
+            userId: editingUserId,
             data: {
               user_template_id: selectedTemplateId,
               note: values.note,
@@ -1076,7 +1077,7 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
         if (editingUser && editingUserId) {
           try {
             await modifyUserMutation.mutateAsync({
-              username: sendValues.username,
+              userId: editingUserId,
               data: sendValues,
             })
             toast.success(
@@ -1307,6 +1308,7 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
   )
 
   const currentUsername = editingUserData?.username || form.getValues('username')
+  const currentUserId = editingUserData?.id || editingUserId
   const isPersianLocale = i18n.language?.toLowerCase().startsWith('fa')
   const formatMetaDate = React.useCallback(
     (value?: string | number | null) => {
@@ -1341,9 +1343,9 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
   }, [editingUserData?.edit_at, formatMetaDate])
 
   const confirmResetUsage = async () => {
-    if (!currentUsername) return
+    if (!currentUserId || !currentUsername) return
     try {
-      await resetUserDataUsageMutation.mutateAsync({ username: currentUsername })
+      await resetUserDataUsageMutation.mutateAsync({ userId: currentUserId })
       toast.success(t('usersTable.resetUsageSuccess', { name: currentUsername }))
       setResetUsageDialogOpen(false)
     } catch (error: any) {
@@ -1352,9 +1354,9 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
   }
 
   const confirmRevokeSubscription = async () => {
-    if (!currentUsername) return
+    if (!currentUserId || !currentUsername) return
     try {
-      await revokeUserSubscriptionMutation.mutateAsync({ username: currentUsername })
+      await revokeUserSubscriptionMutation.mutateAsync({ userId: currentUserId })
       toast.success(t('userDialog.revokeSubSuccess', { name: currentUsername }))
       setRevokeSubDialogOpen(false)
     } catch (error: any) {
@@ -2800,8 +2802,15 @@ function UserModal({ isDialogOpen, onOpenChange, form, editingUser, editingUserI
       </AlertDialog>
 
       {isSudo && currentUsername && <UserAllIPsModal isOpen={isUserAllIPsModalOpen} onOpenChange={setUserAllIPsModalOpen} username={currentUsername} />}
-      {currentUsername && <UsageModal open={isUsageModalOpen} onClose={() => setUsageModalOpen(false)} username={currentUsername} />}
-      {currentUsername && <UserSubscriptionClientsModal isOpen={isSubscriptionClientsModalOpen} onOpenChange={setSubscriptionClientsModalOpen} username={currentUsername} />}
+      {currentUserId && <UsageModal open={isUsageModalOpen} onClose={() => setUsageModalOpen(false)} userId={currentUserId} />}
+      {currentUserId && (
+        <UserSubscriptionClientsModal
+          isOpen={isSubscriptionClientsModalOpen}
+          onOpenChange={setSubscriptionClientsModalOpen}
+          userId={currentUserId}
+          username={currentUsername}
+        />
+      )}
     </Dialog>
   )
 }

--- a/dashboard/src/components/dialogs/user-subscription-clients-modal.tsx
+++ b/dashboard/src/components/dialogs/user-subscription-clients-modal.tsx
@@ -2,11 +2,11 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { useGetUserSubUpdateList, UserSubscriptionUpdateSchema } from '@/service/api'
+import { useGetUserSubUpdateListById, UserSubscriptionUpdateSchema } from '@/service/api'
 import { parseUserAgent, formatClientInfo } from '@/utils/userAgentParser'
 import { dateUtils } from '@/utils/dateFormatter'
 import { Monitor, Smartphone, Globe, HelpCircle, Users, Loader2, ChevronLeft, ChevronRight, Tv } from 'lucide-react'
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import dayjs from '@/lib/dayjs'
 import useDirDetection from '@/hooks/use-dir-detection'
@@ -14,7 +14,8 @@ import useDirDetection from '@/hooks/use-dir-detection'
 interface UserSubscriptionClientsModalProps {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
-  username: string
+  userId: number
+  username?: string
 }
 
 // Function to format time ago
@@ -273,22 +274,31 @@ const detectVersion = (userAgent: string): string => {
   return 'Unknown'
 }
 
-export const UserSubscriptionClientsModal: FC<UserSubscriptionClientsModalProps> = ({ isOpen, onOpenChange, username }) => {
+export const UserSubscriptionClientsModal: FC<UserSubscriptionClientsModalProps> = ({ isOpen, onOpenChange, userId, username }) => {
   const { t } = useTranslation()
   const dir = useDirDetection()
   const [currentPage, setCurrentPage] = useState(0)
   const itemsPerPage = 20
 
+  useEffect(() => {
+    if (!isOpen) {
+      setCurrentPage(0)
+      return
+    }
+
+    setCurrentPage(0)
+  }, [isOpen, userId])
+
   const {
     data: subUpdateList,
     isLoading,
     error,
-  } = useGetUserSubUpdateList(
-    username,
+  } = useGetUserSubUpdateListById(
+    userId,
     { offset: currentPage * itemsPerPage, limit: itemsPerPage },
     {
       query: {
-        enabled: isOpen && !!username,
+        enabled: isOpen && !!userId,
       },
     },
   )
@@ -380,9 +390,11 @@ export const UserSubscriptionClientsModal: FC<UserSubscriptionClientsModalProps>
           <DialogTitle className="flex items-center gap-2">
             <Users className="h-5 w-5 flex-shrink-0" />
             <span>{t('subscriptionClients.title', { defaultValue: 'Subscription Clients' })}</span>
-            <Badge variant="outline" dir="ltr" className="flex-shrink-0">
-              {username}
-            </Badge>
+            {username && (
+              <Badge variant="outline" dir="ltr" className="flex-shrink-0">
+                {username}
+              </Badge>
+            )}
           </DialogTitle>
         </DialogHeader>
 

--- a/dashboard/src/components/users/action-buttons.tsx
+++ b/dashboard/src/components/users/action-buttons.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button'
 import { useClipboard } from '@/hooks/use-clipboard'
 import useDirDetection from '@/hooks/use-dir-detection'
 import { type UseEditFormValues } from '@/components/forms/user-form'
-import { useActiveNextPlan, useGetCurrentAdmin, useRemoveUser, useResetUserDataUsage, useRevokeUserSubscription, UserResponse, UsersResponse } from '@/service/api'
+import { useActiveNextPlanById, useGetCurrentAdmin, useRemoveUserById, useResetUserDataUsageById, useRevokeUserSubscriptionById, UserResponse, UsersResponse } from '@/service/api'
 import { useQueryClient } from '@tanstack/react-query'
 import { Cat, Check, Copy, Cpu, EllipsisVertical, GlobeLock, Link2Off, ListStart, ListTree, Network, Pencil, PieChart, QrCode, RefreshCcw, Trash2, UserCog, Users } from 'lucide-react'
 import { WireguardIcon, XrayIcon, SingboxIcon, MihomoIcon } from '@/components/icons/format-icons'
@@ -247,8 +247,8 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
     invalidateUserMetricsQueries(queryClient)
   }
 
-  const removeUserMutation = useRemoveUser()
-  const resetUserDataUsageMutation = useResetUserDataUsage({
+  const removeUserMutation = useRemoveUserById()
+  const resetUserDataUsageMutation = useResetUserDataUsageById({
     mutation: {
       onSuccess: (updatedUser) => {
         if (updatedUser) {
@@ -257,7 +257,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
       },
     },
   })
-  const revokeUserSubscriptionMutation = useRevokeUserSubscription({
+  const revokeUserSubscriptionMutation = useRevokeUserSubscriptionById({
     mutation: {
       onSuccess: (updatedUser) => {
         if (updatedUser) {
@@ -266,7 +266,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
       },
     },
   })
-  const activeNextMutation = useActiveNextPlan({
+  const activeNextMutation = useActiveNextPlanById({
     mutation: {
       onSuccess: (updatedUser) => {
         if (updatedUser) {
@@ -345,7 +345,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
     let latestUser = user
     for (const [, data] of cachedData) {
       if (data?.users) {
-        const foundUser = data.users.find(u => u.username === user.username)
+        const foundUser = data.users.find(u => u.id === user.id)
         if (foundUser) {
           latestUser = foundUser
           break
@@ -378,7 +378,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
 
   const confirmRevokeSubscription = async () => {
     try {
-      await revokeUserSubscriptionMutation.mutateAsync({ username: user.username })
+      await revokeUserSubscriptionMutation.mutateAsync({ userId: user.id })
       toast.success(t('userDialog.revokeSubSuccess', { name: user.username }))
       setRevokeSubDialogOpen(false)
     } catch (error: any) {
@@ -392,7 +392,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
 
   const activeNextPlan = async () => {
     try {
-      await activeNextMutation.mutateAsync({ username: user.username })
+      await activeNextMutation.mutateAsync({ userId: user.id })
       toast.success(t('userDialog.activeNextPlanSuccess', { name: user.username }))
       setIsActiveNextPlanModalOpen(false)
     } catch (error: any) {
@@ -406,7 +406,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
 
   const confirmResetUsage = async () => {
     try {
-      await resetUserDataUsageMutation.mutateAsync({ username: user.username })
+      await resetUserDataUsageMutation.mutateAsync({ userId: user.id })
       toast.success(t('usersTable.resetUsageSuccess', { name: user.username }))
       setResetUsageDialogOpen(false)
     } catch (error: any) {
@@ -424,7 +424,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
 
   const confirmDelete = async () => {
     try {
-      await removeUserMutation.mutateAsync({ username: user.username })
+      await removeUserMutation.mutateAsync({ userId: user.id })
       toast.success(t('usersTable.deleteSuccess', { name: user.username }))
       setDeleteDialogOpen(false)
       refreshUserData()
@@ -780,13 +780,14 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
             </AlertDialogContent>
           </AlertDialog>
 
-          <UsageModal open={isUsageModalOpen} onClose={() => setUsageModalOpen(false)} username={user.username} />
+          <UsageModal open={isUsageModalOpen} onClose={() => setUsageModalOpen(false)} userId={user.id} />
 
           {/* SetOwnerModal: only for sudo admins */}
           {currentAdmin?.is_sudo && (
             <SetOwnerModal
               open={isSetOwnerModalOpen}
               onClose={() => setSetOwnerModalOpen(false)}
+              userId={user.id}
               username={user.username}
               currentOwner={user.admin?.username}
               onSuccess={(updatedUser?: UserResponse) => {
@@ -798,7 +799,12 @@ const ActionButtons: FC<ActionButtonsProps> = ({ user, isModalHost = true, rende
           )}
 
           {/* UserSubscriptionClientsModal */}
-          <UserSubscriptionClientsModal isOpen={isSubscriptionClientsModalOpen} onOpenChange={setSubscriptionClientsModalOpen} username={user.username} />
+          <UserSubscriptionClientsModal
+            isOpen={isSubscriptionClientsModalOpen}
+            onOpenChange={setSubscriptionClientsModalOpen}
+            userId={user.id}
+            username={user.username}
+          />
 
           {/* UserAllIPsModal: only for sudo admins */}
           {currentAdmin?.is_sudo && <UserAllIPsModal isOpen={isUserAllIPsModalOpen} onOpenChange={setUserAllIPsModalOpen} username={user.username} />}

--- a/dashboard/src/components/users/users-table.tsx
+++ b/dashboard/src/components/users/users-table.tsx
@@ -660,7 +660,7 @@ const UsersTable = memo(() => {
     let latestUser = user
     for (const [, data] of cachedData) {
       if (data?.users) {
-        const foundUser = data.users.find(u => u.username === user.username)
+        const foundUser = data.users.find(u => u.id === user.id)
         if (foundUser) {
           latestUser = foundUser
           break

--- a/dashboard/src/pages/_dashboard._index.tsx
+++ b/dashboard/src/pages/_dashboard._index.tsx
@@ -279,7 +279,7 @@ const Dashboard = () => {
       {/* Only render AdminModal for sudo admins */}
       {is_sudo && isAdminModalOpen && (
         <Suspense fallback={<div />}>
-          <AdminModal isDialogOpen={isAdminModalOpen} onOpenChange={setAdminModalOpen} form={adminForm} editingAdmin={false} editingAdminUserName="" />
+          <AdminModal isDialogOpen={isAdminModalOpen} onOpenChange={setAdminModalOpen} form={adminForm} editingAdmin={false} editingAdminId={undefined} editingAdminUserName="" />
         </Suspense>
       )}
       {isTemplateModalOpen && (

--- a/dashboard/src/pages/_dashboard.admins.tsx
+++ b/dashboard/src/pages/_dashboard.admins.tsx
@@ -8,7 +8,7 @@ import { toast } from 'sonner'
 import AdminsTable from '@/components/admins/admins-table'
 import AdminModal from '@/components/dialogs/admin-modal'
 import { adminFormDefaultValues, adminFormSchema, type AdminFormValuesInput } from '@/components/forms/admin-form'
-import { useActivateAllDisabledUsers, useDisableAllActiveUsers, useModifyAdmin, useRemoveAdmin, useResetAdminUsage } from '@/service/api'
+import { useActivateAllDisabledUsersById, useDisableAllActiveUsersById, useModifyAdminById, useRemoveAdminById, useResetAdminUsageById } from '@/service/api'
 import type { AdminDetails } from '@/service/api'
 import AdminsStatistics from '@/components/admins/admin-statistics'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -27,16 +27,34 @@ export default function AdminsPage() {
     defaultValues: adminFormDefaultValues,
   })
 
-  const removeAdminMutation = useRemoveAdmin()
-  const modifyAdminMutation = useModifyAdmin()
-  const modifyDisableAllAdminUsers = useDisableAllActiveUsers()
-  const modifyActivateAllAdminUsers = useActivateAllDisabledUsers()
-  const resetUsageMutation = useResetAdminUsage()
+  const removeAdminMutation = useRemoveAdminById()
+  const modifyAdminMutation = useModifyAdminById()
+  const modifyDisableAllAdminUsers = useDisableAllActiveUsersById()
+  const modifyActivateAllAdminUsers = useActivateAllDisabledUsersById()
+  const resetUsageMutation = useResetAdminUsageById()
   const handleError = useDynamicErrorHandler()
+
+  const getAdminId = (admin: AdminDetails) => {
+    if (admin.id == null) {
+      toast.error(t('error', { defaultValue: 'Error' }), {
+        description: t('admins.missingId', {
+          name: admin.username,
+          defaultValue: 'Admin "{name}" is missing an id in the current response.',
+        }),
+      })
+      return null
+    }
+
+    return admin.id
+  }
+
   const handleDelete = async (admin: AdminDetails) => {
+    const adminId = getAdminId(admin)
+    if (adminId == null) return
+
     try {
       await removeAdminMutation.mutateAsync({
-        username: admin.username,
+        adminId,
       })
       toast.success(t('success', { defaultValue: 'Success' }), {
         description: t('admins.deleteSuccess', {
@@ -44,7 +62,7 @@ export default function AdminsPage() {
           defaultValue: 'Admin «{{name}}» has been deleted successfully',
         }),
       })
-      removeAdminFromAdminsCache(queryClient, admin.username)
+      removeAdminFromAdminsCache(queryClient, adminId)
     } catch (error) {
       handleError({
         error,
@@ -56,20 +74,23 @@ export default function AdminsPage() {
   }
 
   const handleToggleStatus = async (admin: AdminDetails, checked: boolean) => {
+    const adminId = getAdminId(admin)
+    if (adminId == null) return
+
     try {
       if (!admin.is_disabled && checked) {
         await modifyDisableAllAdminUsers.mutateAsync({
-          username: admin.username,
+          adminId,
         })
       }
 
       if (admin.is_disabled && checked) {
         await modifyActivateAllAdminUsers.mutateAsync({
-          username: admin.username,
+          adminId,
         })
       }
       const updatedAdmin = await modifyAdminMutation.mutateAsync({
-        username: admin.username,
+        adminId,
         data: {
           is_sudo: admin.is_sudo,
           is_disabled: !admin.is_disabled,
@@ -134,16 +155,19 @@ export default function AdminsPage() {
     setIsDialogOpen(true)
   }
 
-  const resetUsage = async (adminUsername: string) => {
+  const resetUsage = async (admin: AdminDetails) => {
+    const adminId = getAdminId(admin)
+    if (adminId == null) return
+
     try {
       const updatedAdmin = await resetUsageMutation.mutateAsync({
-        username: adminUsername,
+        adminId,
       })
       upsertAdminInAdminsCache(queryClient, updatedAdmin, { allowInsert: true })
 
       toast.success(t('success', { defaultValue: 'Success' }), {
         description: t('admins.resetUsageSuccess', {
-          name: adminUsername,
+          name: admin.username,
           defaultValue: `Admin "{name}" user usage has been reset successfully`,
         }),
       })
@@ -151,7 +175,7 @@ export default function AdminsPage() {
     } catch (error) {
       toast.error(t('error', { defaultValue: 'Error' }), {
         description: t('admins.resetUsageFailed', {
-          name: adminUsername,
+          name: admin.username,
           defaultValue: `Failed to reset admin "{name}" user usage`,
         }),
       })
@@ -195,6 +219,7 @@ export default function AdminsPage() {
           }}
           form={form}
           editingAdmin={!!editingAdmin}
+          editingAdminId={editingAdmin?.id}
           editingAdminUserName={editingAdmin?.username || ''}
         />
       </div>

--- a/dashboard/src/service/api/index.ts
+++ b/dashboard/src/service/api/index.ts
@@ -79,6 +79,22 @@ export type GetUsersUsageParams = {
   admin?: string[] | null
 }
 
+export type GetUserUsageByIdParams = {
+  period: Period
+  node_id?: number | null
+  group_by_node?: boolean
+  start?: string | null
+  end?: string | null
+}
+
+export type GetUserUsageByUsernameParams = {
+  period: Period
+  node_id?: number | null
+  group_by_node?: boolean
+  start?: string | null
+  end?: string | null
+}
+
 export type GetUserUsageParams = {
   period: Period
   node_id?: number | null
@@ -108,9 +124,27 @@ export type GetUsersParams = {
   load_sub?: boolean
 }
 
+export type GetUserSubUpdateListByIdParams = {
+  offset?: number
+  limit?: number
+}
+
+export type GetUserSubUpdateListByUsernameParams = {
+  offset?: number
+  limit?: number
+}
+
 export type GetUserSubUpdateListParams = {
   offset?: number
   limit?: number
+}
+
+export type SetOwnerByIdParams = {
+  admin_username: string
+}
+
+export type SetOwnerByUsernameParams = {
+  admin_username: string
 }
 
 export type SetOwnerParams = {
@@ -118,6 +152,7 @@ export type SetOwnerParams = {
 }
 
 export type GetUsersSubUpdateChartParams = {
+  user_id?: number | null
   username?: string | null
   admin_id?: number | null
 }
@@ -227,6 +262,22 @@ export type GetAllGroupsParams = {
 
 export type GetSystemStatsParams = {
   admin_username?: string | null
+}
+
+export type GetAdminUsageByIdParams = {
+  period: Period
+  node_id?: number | null
+  group_by_node?: boolean
+  start?: string | null
+  end?: string | null
+}
+
+export type GetAdminUsageByUsernameParams = {
+  period: Period
+  node_id?: number | null
+  group_by_node?: boolean
+  start?: string | null
+  end?: string | null
 }
 
 export type GetAdminUsageParams = {
@@ -459,18 +510,6 @@ export type XHttpSettingsInputXPaddingBytes = string | number | null
 
 export type XHttpSettingsInputNoGrpcHeader = boolean | null
 
-export type XHttpModes = (typeof XHttpModes)[keyof typeof XHttpModes]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const XHttpModes = {
-  auto: 'auto',
-  'packet-up': 'packet-up',
-  'stream-up': 'stream-up',
-  'stream-one': 'stream-one',
-} as const
-
-export type XHttpSettingsInputMode = XHttpModes | null
-
 export interface XHttpSettingsInput {
   mode?: XHttpSettingsInputMode
   no_grpc_header?: XHttpSettingsInputNoGrpcHeader
@@ -494,6 +533,23 @@ export interface XHttpSettingsInput {
   download_settings?: XHttpSettingsInputDownloadSettings
 }
 
+export type XHttpModes = (typeof XHttpModes)[keyof typeof XHttpModes]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const XHttpModes = {
+  auto: 'auto',
+  'packet-up': 'packet-up',
+  'stream-up': 'stream-up',
+  'stream-one': 'stream-one',
+} as const
+
+export type XHttpSettingsInputMode = XHttpModes | null
+
+export interface WorkersHealth {
+  scheduler: WorkerHealth
+  node: WorkerHealth
+}
+
 export type WorkerHealthError = string | null
 
 export type WorkerHealthResponseTimeMs = number | null
@@ -502,11 +558,6 @@ export interface WorkerHealth {
   status: string
   response_time_ms?: WorkerHealthResponseTimeMs
   error?: WorkerHealthError
-}
-
-export interface WorkersHealth {
-  scheduler: WorkerHealth
-  node: WorkerHealth
 }
 
 export type WireGuardSettingsPublicKey = string | null
@@ -618,19 +669,19 @@ export const UsernameGenerationStrategy = {
 
 export type UserUsageStatsListPeriod = Period | null
 
-export interface UserUsageStatsList {
-  period?: UserUsageStatsListPeriod
-  start: string
-  end: string
-  stats: UserUsageStatsListStats
-}
-
 export interface UserUsageStat {
   total_traffic: number
   period_start: string
 }
 
 export type UserUsageStatsListStats = { [key: string]: UserUsageStat[] }
+
+export interface UserUsageStatsList {
+  period?: UserUsageStatsListPeriod
+  start: string
+  end: string
+  stats: UserUsageStatsListStats
+}
 
 export type UserTemplateSimpleName = string | null
 
@@ -940,6 +991,13 @@ export interface UserModify {
   status?: UserModifyStatus
 }
 
+/**
+ * User IP lists for all nodes
+ */
+export interface UserIPListAll {
+  nodes: UserIPListAllNodes
+}
+
 export type UserIPListIps = { [key: string]: number }
 
 /**
@@ -950,13 +1008,6 @@ export interface UserIPList {
 }
 
 export type UserIPListAllNodes = { [key: string]: UserIPList | null }
-
-/**
- * User IP lists for all nodes
- */
-export interface UserIPListAll {
-  nodes: UserIPListAllNodes
-}
 
 export type UserCreateStatus = UserStatusCreate | null
 
@@ -1033,8 +1084,6 @@ export interface TransportSettingsOutput {
 
 export type TransportSettingsInputWebsocketSettings = WebSocketSettings | null
 
-export type TransportSettingsInputTcpSettings = TcpSettings | null
-
 export type TransportSettingsInputKcpSettings = KCPSettings | null
 
 export type TransportSettingsInputGrpcSettings = GRPCSettings | null
@@ -1086,6 +1135,8 @@ export interface TcpSettings {
   request?: TcpSettingsRequest
   response?: TcpSettingsResponse
 }
+
+export type TransportSettingsInputTcpSettings = TcpSettings | null
 
 export type SystemStatsCpuUsage = number | null
 
@@ -1485,6 +1536,19 @@ export type NotificationSettingsInputTelegramChatId = number | null
 
 export type NotificationSettingsInputTelegramApiToken = string | null
 
+export interface NotificationSettingsInput {
+  notify_telegram?: boolean
+  notify_discord?: boolean
+  telegram_api_token?: NotificationSettingsInputTelegramApiToken
+  telegram_chat_id?: NotificationSettingsInputTelegramChatId
+  telegram_topic_id?: NotificationSettingsInputTelegramTopicId
+  discord_webhook_url?: NotificationSettingsInputDiscordWebhookUrl
+  channels?: NotificationChannels
+  proxy_url?: NotificationSettingsInputProxyUrl
+  /** */
+  max_retries: number
+}
+
 export interface NotificationEnable {
   admin?: AdminNotificationEnable
   core?: BaseNotificationEnable
@@ -1495,21 +1559,6 @@ export interface NotificationEnable {
   user_template?: BaseNotificationEnable
   days_left?: boolean
   percentage_reached?: boolean
-}
-
-export type NotificationChannelDiscordWebhookUrl = string | null
-
-export type NotificationChannelTelegramTopicId = number | null
-
-export type NotificationChannelTelegramChatId = number | null
-
-/**
- * Channel configuration for sending notifications to a specific entity
- */
-export interface NotificationChannel {
-  telegram_chat_id?: NotificationChannelTelegramChatId
-  telegram_topic_id?: NotificationChannelTelegramTopicId
-  discord_webhook_url?: NotificationChannelDiscordWebhookUrl
 }
 
 /**
@@ -1525,17 +1574,19 @@ export interface NotificationChannels {
   user_template?: NotificationChannel
 }
 
-export interface NotificationSettingsInput {
-  notify_telegram?: boolean
-  notify_discord?: boolean
-  telegram_api_token?: NotificationSettingsInputTelegramApiToken
-  telegram_chat_id?: NotificationSettingsInputTelegramChatId
-  telegram_topic_id?: NotificationSettingsInputTelegramTopicId
-  discord_webhook_url?: NotificationSettingsInputDiscordWebhookUrl
-  channels?: NotificationChannels
-  proxy_url?: NotificationSettingsInputProxyUrl
-  /** */
-  max_retries: number
+export type NotificationChannelDiscordWebhookUrl = string | null
+
+export type NotificationChannelTelegramTopicId = number | null
+
+export type NotificationChannelTelegramChatId = number | null
+
+/**
+ * Channel configuration for sending notifications to a specific entity
+ */
+export interface NotificationChannel {
+  telegram_chat_id?: NotificationChannelTelegramChatId
+  telegram_topic_id?: NotificationChannelTelegramTopicId
+  discord_webhook_url?: NotificationChannelDiscordWebhookUrl
 }
 
 export interface NotFound {
@@ -1561,8 +1612,6 @@ export interface NodesResponse {
   total: number
 }
 
-export type NodeUsageStatsListStats = { [key: string]: NodeUsageStat[] }
-
 export type NodeUsageStatsListPeriod = Period | null
 
 export interface NodeUsageStatsList {
@@ -1577,6 +1626,8 @@ export interface NodeUsageStat {
   downlink: number
   period_start: string
 }
+
+export type NodeUsageStatsListStats = { [key: string]: NodeUsageStat[] }
 
 export type NodeStatus = (typeof NodeStatus)[keyof typeof NodeStatus]
 
@@ -1744,6 +1795,19 @@ export interface NodeGeoFilesUpdate {
   region?: GeoFilseRegion
 }
 
+export interface NodeCoreUpdate {
+  /** @pattern ^(latest|v?\d+\.\d+\.\d+)$ */
+  core_version?: string
+}
+
+export type NodeConnectionType = (typeof NodeConnectionType)[keyof typeof NodeConnectionType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const NodeConnectionType = {
+  grpc: 'grpc',
+  rest: 'rest',
+} as const
+
 export interface NodeCreate {
   name: string
   address: string
@@ -1770,19 +1834,6 @@ export interface NodeCreate {
    */
   internal_timeout?: number
 }
-
-export interface NodeCoreUpdate {
-  /** @pattern ^(latest|v?\d+\.\d+\.\d+)$ */
-  core_version?: string
-}
-
-export type NodeConnectionType = (typeof NodeConnectionType)[keyof typeof NodeConnectionType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const NodeConnectionType = {
-  grpc: 'grpc',
-  rest: 'rest',
-} as const
 
 export type NextPlanModelExpire = number | null
 
@@ -2101,6 +2152,26 @@ export type CreateHostMuxSettings = MuxSettingsInput | null
 
 export type CreateHostTransportSettings = TransportSettingsInput | null
 
+export type CreateHostHttpHeadersAnyOf = { [key: string]: string }
+
+export type CreateHostHttpHeaders = CreateHostHttpHeadersAnyOf | null
+
+export type CreateHostAllowinsecure = boolean | null
+
+export type CreateHostAlpn = ProxyHostALPN[] | null
+
+export type CreateHostPath = string | null
+
+export type CreateHostHost = string[] | null
+
+export type CreateHostSni = string[] | null
+
+export type CreateHostPort = number | null
+
+export type CreateHostInboundTag = string | null
+
+export type CreateHostId = number | null
+
 export interface CreateHost {
   id?: CreateHostId
   remark: string
@@ -2132,26 +2203,6 @@ export interface CreateHost {
   wireguard_overrides?: CreateHostWireguardOverrides
   subscription_templates?: CreateHostSubscriptionTemplates
 }
-
-export type CreateHostHttpHeadersAnyOf = { [key: string]: string }
-
-export type CreateHostHttpHeaders = CreateHostHttpHeadersAnyOf | null
-
-export type CreateHostAllowinsecure = boolean | null
-
-export type CreateHostAlpn = ProxyHostALPN[] | null
-
-export type CreateHostPath = string | null
-
-export type CreateHostHost = string[] | null
-
-export type CreateHostSni = string[] | null
-
-export type CreateHostPort = number | null
-
-export type CreateHostInboundTag = string | null
-
-export type CreateHostId = number | null
 
 /**
  * Response model for lightweight core list.
@@ -2556,26 +2607,6 @@ export type BaseHostMuxSettings = MuxSettingsOutput | null
 
 export type BaseHostTransportSettings = TransportSettingsOutput | null
 
-export type BaseHostHttpHeadersAnyOf = { [key: string]: string }
-
-export type BaseHostHttpHeaders = BaseHostHttpHeadersAnyOf | null
-
-export type BaseHostAllowinsecure = boolean | null
-
-export type BaseHostAlpn = ProxyHostALPN[] | null
-
-export type BaseHostPath = string | null
-
-export type BaseHostHost = string[] | null
-
-export type BaseHostSni = string[] | null
-
-export type BaseHostPort = number | null
-
-export type BaseHostInboundTag = string | null
-
-export type BaseHostId = number | null
-
 export interface BaseHost {
   id?: BaseHostId
   remark: string
@@ -2607,6 +2638,26 @@ export interface BaseHost {
   wireguard_overrides?: BaseHostWireguardOverrides
   subscription_templates?: BaseHostSubscriptionTemplates
 }
+
+export type BaseHostHttpHeadersAnyOf = { [key: string]: string }
+
+export type BaseHostHttpHeaders = BaseHostHttpHeadersAnyOf | null
+
+export type BaseHostAllowinsecure = boolean | null
+
+export type BaseHostAlpn = ProxyHostALPN[] | null
+
+export type BaseHostPath = string | null
+
+export type BaseHostHost = string[] | null
+
+export type BaseHostSni = string[] | null
+
+export type BaseHostPort = number | null
+
+export type BaseHostInboundTag = string | null
+
+export type BaseHostId = number | null
 
 export type ApplicationOutputDescription = { [key: string]: string }
 
@@ -3225,6 +3276,194 @@ export const useRemoveAdmin = <TData = Awaited<ReturnType<typeof removeAdmin>>, 
 }
 
 /**
+ * @summary Modify Admin By Username
+ */
+export const modifyAdminByUsername = (username: string, adminModify: BodyType<AdminModify>) => {
+  return orvalFetcher<AdminDetails>({ url: `/api/admin/by-username/${username}`, method: 'PUT', headers: { 'Content-Type': 'application/json' }, data: adminModify })
+}
+
+export const getModifyAdminByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof modifyAdminByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | Conflict | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<AdminModify> }, TContext>
+}) => {
+  const mutationKey = ['modifyAdminByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof modifyAdminByUsername>>, { username: string; data: BodyType<AdminModify> }> = props => {
+    const { username, data } = props ?? {}
+
+    return modifyAdminByUsername(username, data)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string; data: BodyType<AdminModify> }, TContext>
+}
+
+export type ModifyAdminByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof modifyAdminByUsername>>>
+export type ModifyAdminByUsernameMutationBody = BodyType<AdminModify>
+export type ModifyAdminByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | Conflict | HTTPValidationError>
+
+/**
+ * @summary Modify Admin By Username
+ */
+export const useModifyAdminByUsername = <
+  TData = Awaited<ReturnType<typeof modifyAdminByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | Conflict | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<AdminModify> }, TContext>
+}): UseMutationResult<TData, TError, { username: string; data: BodyType<AdminModify> }, TContext> => {
+  const mutationOptions = getModifyAdminByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Remove Admin By Username
+ */
+export const removeAdminByUsername = (username: string) => {
+  return orvalFetcher<void>({ url: `/api/admin/by-username/${username}`, method: 'DELETE' })
+}
+
+export const getRemoveAdminByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof removeAdminByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['removeAdminByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof removeAdminByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return removeAdminByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type RemoveAdminByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof removeAdminByUsername>>>
+
+export type RemoveAdminByUsernameMutationError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>
+
+/**
+ * @summary Remove Admin By Username
+ */
+export const useRemoveAdminByUsername = <TData = Awaited<ReturnType<typeof removeAdminByUsername>>, TError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getRemoveAdminByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Modify Admin By Id
+ */
+export const modifyAdminById = (adminId: number, adminModify: BodyType<AdminModify>) => {
+  return orvalFetcher<AdminDetails>({ url: `/api/admin/by-id/${adminId}`, method: 'PUT', headers: { 'Content-Type': 'application/json' }, data: adminModify })
+}
+
+export const getModifyAdminByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof modifyAdminById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | Conflict | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number; data: BodyType<AdminModify> }, TContext>
+}) => {
+  const mutationKey = ['modifyAdminById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof modifyAdminById>>, { adminId: number; data: BodyType<AdminModify> }> = props => {
+    const { adminId, data } = props ?? {}
+
+    return modifyAdminById(adminId, data)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { adminId: number; data: BodyType<AdminModify> }, TContext>
+}
+
+export type ModifyAdminByIdMutationResult = NonNullable<Awaited<ReturnType<typeof modifyAdminById>>>
+export type ModifyAdminByIdMutationBody = BodyType<AdminModify>
+export type ModifyAdminByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | Conflict | HTTPValidationError>
+
+/**
+ * @summary Modify Admin By Id
+ */
+export const useModifyAdminById = <
+  TData = Awaited<ReturnType<typeof modifyAdminById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | Conflict | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number; data: BodyType<AdminModify> }, TContext>
+}): UseMutationResult<TData, TError, { adminId: number; data: BodyType<AdminModify> }, TContext> => {
+  const mutationOptions = getModifyAdminByIdMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Remove Admin By Id
+ */
+export const removeAdminById = (adminId: number) => {
+  return orvalFetcher<void>({ url: `/api/admin/by-id/${adminId}`, method: 'DELETE' })
+}
+
+export const getRemoveAdminByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof removeAdminById>>,
+  TError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}) => {
+  const mutationKey = ['removeAdminById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof removeAdminById>>, { adminId: number }> = props => {
+    const { adminId } = props ?? {}
+
+    return removeAdminById(adminId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}
+
+export type RemoveAdminByIdMutationResult = NonNullable<Awaited<ReturnType<typeof removeAdminById>>>
+
+export type RemoveAdminByIdMutationError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>
+
+/**
+ * @summary Remove Admin By Id
+ */
+export const useRemoveAdminById = <TData = Awaited<ReturnType<typeof removeAdminById>>, TError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}): UseMutationResult<TData, TError, { adminId: number }, TContext> => {
+  const mutationOptions = getRemoveAdminByIdMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
  * Fetch a list of admins with optional filters for pagination and username.
  * @summary Get Admins
  */
@@ -3416,6 +3655,142 @@ export function useGetAdminUsage<TData = Awaited<ReturnType<typeof getAdminUsage
 }
 
 /**
+ * @summary Get Admin Usage By Username
+ */
+export const getAdminUsageByUsername = (username: string, params: GetAdminUsageByUsernameParams, signal?: AbortSignal) => {
+  return orvalFetcher<UserUsageStatsList>({ url: `/api/admin/by-username/${username}/usage`, method: 'GET', params, signal })
+}
+
+export const getGetAdminUsageByUsernameQueryKey = (username: string, params: GetAdminUsageByUsernameParams) => {
+  return [`/api/admin/by-username/${username}/usage`, ...(params ? [params] : [])] as const
+}
+
+export const getGetAdminUsageByUsernameQueryOptions = <TData = Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetAdminUsageByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError, TData>> },
+) => {
+  const { query: queryOptions } = options ?? {}
+
+  const queryKey = queryOptions?.queryKey ?? getGetAdminUsageByUsernameQueryKey(username, params)
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getAdminUsageByUsername>>> = ({ signal }) => getAdminUsageByUsername(username, params, signal)
+
+  return { queryKey, queryFn, enabled: !!username, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData, TError>
+  }
+}
+
+export type GetAdminUsageByUsernameQueryResult = NonNullable<Awaited<ReturnType<typeof getAdminUsageByUsername>>>
+export type GetAdminUsageByUsernameQueryError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+export function useGetAdminUsageByUsername<TData = Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetAdminUsageByUsernameParams,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError, TData>> &
+      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError, TData>, 'initialData'>
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetAdminUsageByUsername<TData = Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetAdminUsageByUsernameParams,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError, TData>, 'initialData'>
+  },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetAdminUsageByUsername<TData = Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetAdminUsageByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get Admin Usage By Username
+ */
+
+export function useGetAdminUsageByUsername<TData = Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetAdminUsageByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageByUsername>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetAdminUsageByUsernameQueryOptions(username, params, options)
+
+  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  query.queryKey = queryOptions.queryKey
+
+  return query
+}
+
+/**
+ * @summary Get Admin Usage By Id
+ */
+export const getAdminUsageById = (adminId: number, params: GetAdminUsageByIdParams, signal?: AbortSignal) => {
+  return orvalFetcher<UserUsageStatsList>({ url: `/api/admin/by-id/${adminId}/usage`, method: 'GET', params, signal })
+}
+
+export const getGetAdminUsageByIdQueryKey = (adminId: number, params: GetAdminUsageByIdParams) => {
+  return [`/api/admin/by-id/${adminId}/usage`, ...(params ? [params] : [])] as const
+}
+
+export const getGetAdminUsageByIdQueryOptions = <TData = Awaited<ReturnType<typeof getAdminUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  adminId: number,
+  params: GetAdminUsageByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageById>>, TError, TData>> },
+) => {
+  const { query: queryOptions } = options ?? {}
+
+  const queryKey = queryOptions?.queryKey ?? getGetAdminUsageByIdQueryKey(adminId, params)
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getAdminUsageById>>> = ({ signal }) => getAdminUsageById(adminId, params, signal)
+
+  return { queryKey, queryFn, enabled: !!adminId, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageById>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type GetAdminUsageByIdQueryResult = NonNullable<Awaited<ReturnType<typeof getAdminUsageById>>>
+export type GetAdminUsageByIdQueryError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+export function useGetAdminUsageById<TData = Awaited<ReturnType<typeof getAdminUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  adminId: number,
+  params: GetAdminUsageByIdParams,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageById>>, TError, TData>> &
+      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof getAdminUsageById>>, TError, TData>, 'initialData'>
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetAdminUsageById<TData = Awaited<ReturnType<typeof getAdminUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  adminId: number,
+  params: GetAdminUsageByIdParams,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageById>>, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof getAdminUsageById>>, TError, TData>, 'initialData'>
+  },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetAdminUsageById<TData = Awaited<ReturnType<typeof getAdminUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  adminId: number,
+  params: GetAdminUsageByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageById>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get Admin Usage By Id
+ */
+
+export function useGetAdminUsageById<TData = Awaited<ReturnType<typeof getAdminUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  adminId: number,
+  params: GetAdminUsageByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getAdminUsageById>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetAdminUsageByIdQueryOptions(adminId, params, options)
+
+  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  query.queryKey = queryOptions.queryKey
+
+  return query
+}
+
+/**
  * Disable all active users under a specific admin
  * @summary Disable All Active Users
  */
@@ -3461,6 +3836,104 @@ export const useDisableAllActiveUsers = <
   mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
 }): UseMutationResult<TData, TError, { username: string }, TContext> => {
   const mutationOptions = getDisableAllActiveUsersMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Disable All Active Users By Username
+ */
+export const disableAllActiveUsersByUsername = (username: string, signal?: AbortSignal) => {
+  return orvalFetcher<unknown>({ url: `/api/admin/by-username/${username}/users/disable`, method: 'POST', signal })
+}
+
+export const getDisableAllActiveUsersByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof disableAllActiveUsersByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['disableAllActiveUsersByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof disableAllActiveUsersByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return disableAllActiveUsersByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type DisableAllActiveUsersByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof disableAllActiveUsersByUsername>>>
+
+export type DisableAllActiveUsersByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Disable All Active Users By Username
+ */
+export const useDisableAllActiveUsersByUsername = <
+  TData = Awaited<ReturnType<typeof disableAllActiveUsersByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getDisableAllActiveUsersByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Disable All Active Users By Id
+ */
+export const disableAllActiveUsersById = (adminId: number, signal?: AbortSignal) => {
+  return orvalFetcher<unknown>({ url: `/api/admin/by-id/${adminId}/users/disable`, method: 'POST', signal })
+}
+
+export const getDisableAllActiveUsersByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof disableAllActiveUsersById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}) => {
+  const mutationKey = ['disableAllActiveUsersById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof disableAllActiveUsersById>>, { adminId: number }> = props => {
+    const { adminId } = props ?? {}
+
+    return disableAllActiveUsersById(adminId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}
+
+export type DisableAllActiveUsersByIdMutationResult = NonNullable<Awaited<ReturnType<typeof disableAllActiveUsersById>>>
+
+export type DisableAllActiveUsersByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Disable All Active Users By Id
+ */
+export const useDisableAllActiveUsersById = <
+  TData = Awaited<ReturnType<typeof disableAllActiveUsersById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}): UseMutationResult<TData, TError, { adminId: number }, TContext> => {
+  const mutationOptions = getDisableAllActiveUsersByIdMutationOptions(options)
 
   return useMutation(mutationOptions)
 }
@@ -3516,6 +3989,104 @@ export const useActivateAllDisabledUsers = <
 }
 
 /**
+ * @summary Activate All Disabled Users By Username
+ */
+export const activateAllDisabledUsersByUsername = (username: string, signal?: AbortSignal) => {
+  return orvalFetcher<unknown>({ url: `/api/admin/by-username/${username}/users/activate`, method: 'POST', signal })
+}
+
+export const getActivateAllDisabledUsersByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof activateAllDisabledUsersByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['activateAllDisabledUsersByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof activateAllDisabledUsersByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return activateAllDisabledUsersByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type ActivateAllDisabledUsersByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof activateAllDisabledUsersByUsername>>>
+
+export type ActivateAllDisabledUsersByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Activate All Disabled Users By Username
+ */
+export const useActivateAllDisabledUsersByUsername = <
+  TData = Awaited<ReturnType<typeof activateAllDisabledUsersByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getActivateAllDisabledUsersByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Activate All Disabled Users By Id
+ */
+export const activateAllDisabledUsersById = (adminId: number, signal?: AbortSignal) => {
+  return orvalFetcher<unknown>({ url: `/api/admin/by-id/${adminId}/users/activate`, method: 'POST', signal })
+}
+
+export const getActivateAllDisabledUsersByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof activateAllDisabledUsersById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}) => {
+  const mutationKey = ['activateAllDisabledUsersById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof activateAllDisabledUsersById>>, { adminId: number }> = props => {
+    const { adminId } = props ?? {}
+
+    return activateAllDisabledUsersById(adminId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}
+
+export type ActivateAllDisabledUsersByIdMutationResult = NonNullable<Awaited<ReturnType<typeof activateAllDisabledUsersById>>>
+
+export type ActivateAllDisabledUsersByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Activate All Disabled Users By Id
+ */
+export const useActivateAllDisabledUsersById = <
+  TData = Awaited<ReturnType<typeof activateAllDisabledUsersById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}): UseMutationResult<TData, TError, { adminId: number }, TContext> => {
+  const mutationOptions = getActivateAllDisabledUsersByIdMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
  * Remove all users under a specific admin.
  * @summary Remove All Users
  */
@@ -3562,6 +4133,104 @@ export const useRemoveAllUsers = <TData = Awaited<ReturnType<typeof removeAllUse
 }
 
 /**
+ * @summary Remove All Users By Username
+ */
+export const removeAllUsersByUsername = (username: string) => {
+  return orvalFetcher<unknown>({ url: `/api/admin/by-username/${username}/users`, method: 'DELETE' })
+}
+
+export const getRemoveAllUsersByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof removeAllUsersByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['removeAllUsersByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof removeAllUsersByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return removeAllUsersByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type RemoveAllUsersByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof removeAllUsersByUsername>>>
+
+export type RemoveAllUsersByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Remove All Users By Username
+ */
+export const useRemoveAllUsersByUsername = <
+  TData = Awaited<ReturnType<typeof removeAllUsersByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getRemoveAllUsersByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Remove All Users By Id
+ */
+export const removeAllUsersById = (adminId: number) => {
+  return orvalFetcher<unknown>({ url: `/api/admin/by-id/${adminId}/users`, method: 'DELETE' })
+}
+
+export const getRemoveAllUsersByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof removeAllUsersById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}) => {
+  const mutationKey = ['removeAllUsersById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof removeAllUsersById>>, { adminId: number }> = props => {
+    const { adminId } = props ?? {}
+
+    return removeAllUsersById(adminId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}
+
+export type RemoveAllUsersByIdMutationResult = NonNullable<Awaited<ReturnType<typeof removeAllUsersById>>>
+
+export type RemoveAllUsersByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Remove All Users By Id
+ */
+export const useRemoveAllUsersById = <
+  TData = Awaited<ReturnType<typeof removeAllUsersById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}): UseMutationResult<TData, TError, { adminId: number }, TContext> => {
+  const mutationOptions = getRemoveAllUsersByIdMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
  * Resets usage of admin.
  * @summary Reset Admin Usage
  */
@@ -3603,6 +4272,104 @@ export const useResetAdminUsage = <TData = Awaited<ReturnType<typeof resetAdminU
   mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
 }): UseMutationResult<TData, TError, { username: string }, TContext> => {
   const mutationOptions = getResetAdminUsageMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Reset Admin Usage By Username
+ */
+export const resetAdminUsageByUsername = (username: string, signal?: AbortSignal) => {
+  return orvalFetcher<AdminDetails>({ url: `/api/admin/by-username/${username}/reset`, method: 'POST', signal })
+}
+
+export const getResetAdminUsageByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof resetAdminUsageByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['resetAdminUsageByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof resetAdminUsageByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return resetAdminUsageByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type ResetAdminUsageByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof resetAdminUsageByUsername>>>
+
+export type ResetAdminUsageByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Reset Admin Usage By Username
+ */
+export const useResetAdminUsageByUsername = <
+  TData = Awaited<ReturnType<typeof resetAdminUsageByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getResetAdminUsageByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Reset Admin Usage By Id
+ */
+export const resetAdminUsageById = (adminId: number, signal?: AbortSignal) => {
+  return orvalFetcher<AdminDetails>({ url: `/api/admin/by-id/${adminId}/reset`, method: 'POST', signal })
+}
+
+export const getResetAdminUsageByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof resetAdminUsageById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}) => {
+  const mutationKey = ['resetAdminUsageById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof resetAdminUsageById>>, { adminId: number }> = props => {
+    const { adminId } = props ?? {}
+
+    return resetAdminUsageById(adminId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}
+
+export type ResetAdminUsageByIdMutationResult = NonNullable<Awaited<ReturnType<typeof resetAdminUsageById>>>
+
+export type ResetAdminUsageByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Reset Admin Usage By Id
+ */
+export const useResetAdminUsageById = <
+  TData = Awaited<ReturnType<typeof resetAdminUsageById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { adminId: number }, TContext>
+}): UseMutationResult<TData, TError, { adminId: number }, TContext> => {
+  const mutationOptions = getResetAdminUsageByIdMutationOptions(options)
 
   return useMutation(mutationOptions)
 }
@@ -7905,6 +8672,320 @@ export function useGetUser<TData = Awaited<ReturnType<typeof getUser>>, TError =
 }
 
 /**
+ * @summary Modify User By Username
+ */
+export const modifyUserByUsername = (username: string, userModify: BodyType<UserModify>) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-username/${username}`, method: 'PUT', headers: { 'Content-Type': 'application/json' }, data: userModify })
+}
+
+export const getModifyUserByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof modifyUserByUsername>>,
+  TError = ErrorType<HTTPException | Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<UserModify> }, TContext>
+}) => {
+  const mutationKey = ['modifyUserByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof modifyUserByUsername>>, { username: string; data: BodyType<UserModify> }> = props => {
+    const { username, data } = props ?? {}
+
+    return modifyUserByUsername(username, data)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string; data: BodyType<UserModify> }, TContext>
+}
+
+export type ModifyUserByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof modifyUserByUsername>>>
+export type ModifyUserByUsernameMutationBody = BodyType<UserModify>
+export type ModifyUserByUsernameMutationError = ErrorType<HTTPException | Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Modify User By Username
+ */
+export const useModifyUserByUsername = <
+  TData = Awaited<ReturnType<typeof modifyUserByUsername>>,
+  TError = ErrorType<HTTPException | Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<UserModify> }, TContext>
+}): UseMutationResult<TData, TError, { username: string; data: BodyType<UserModify> }, TContext> => {
+  const mutationOptions = getModifyUserByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Remove User By Username
+ */
+export const removeUserByUsername = (username: string) => {
+  return orvalFetcher<void>({ url: `/api/user/by-username/${username}`, method: 'DELETE' })
+}
+
+export const getRemoveUserByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof removeUserByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['removeUserByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof removeUserByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return removeUserByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type RemoveUserByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof removeUserByUsername>>>
+
+export type RemoveUserByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Remove User By Username
+ */
+export const useRemoveUserByUsername = <
+  TData = Awaited<ReturnType<typeof removeUserByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getRemoveUserByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Get User By Username
+ */
+export const getUserByUsername = (username: string, signal?: AbortSignal) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-username/${username}`, method: 'GET', signal })
+}
+
+export const getGetUserByUsernameQueryKey = (username: string) => {
+  return [`/api/user/by-username/${username}`] as const
+}
+
+export const getGetUserByUsernameQueryOptions = <TData = Awaited<ReturnType<typeof getUserByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserByUsername>>, TError, TData>> },
+) => {
+  const { query: queryOptions } = options ?? {}
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserByUsernameQueryKey(username)
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserByUsername>>> = ({ signal }) => getUserByUsername(username, signal)
+
+  return { queryKey, queryFn, enabled: !!username, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof getUserByUsername>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type GetUserByUsernameQueryResult = NonNullable<Awaited<ReturnType<typeof getUserByUsername>>>
+export type GetUserByUsernameQueryError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+export function useGetUserByUsername<TData = Awaited<ReturnType<typeof getUserByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserByUsername>>, TError, TData>> &
+      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof getUserByUsername>>, TError, TData>, 'initialData'>
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserByUsername<TData = Awaited<ReturnType<typeof getUserByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserByUsername>>, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof getUserByUsername>>, TError, TData>, 'initialData'>
+  },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserByUsername<TData = Awaited<ReturnType<typeof getUserByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserByUsername>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get User By Username
+ */
+
+export function useGetUserByUsername<TData = Awaited<ReturnType<typeof getUserByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserByUsername>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetUserByUsernameQueryOptions(username, options)
+
+  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  query.queryKey = queryOptions.queryKey
+
+  return query
+}
+
+/**
+ * @summary Modify User By Id
+ */
+export const modifyUserById = (userId: number, userModify: BodyType<UserModify>) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-id/${userId}`, method: 'PUT', headers: { 'Content-Type': 'application/json' }, data: userModify })
+}
+
+export const getModifyUserByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof modifyUserById>>,
+  TError = ErrorType<HTTPException | Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number; data: BodyType<UserModify> }, TContext>
+}) => {
+  const mutationKey = ['modifyUserById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof modifyUserById>>, { userId: number; data: BodyType<UserModify> }> = props => {
+    const { userId, data } = props ?? {}
+
+    return modifyUserById(userId, data)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { userId: number; data: BodyType<UserModify> }, TContext>
+}
+
+export type ModifyUserByIdMutationResult = NonNullable<Awaited<ReturnType<typeof modifyUserById>>>
+export type ModifyUserByIdMutationBody = BodyType<UserModify>
+export type ModifyUserByIdMutationError = ErrorType<HTTPException | Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Modify User By Id
+ */
+export const useModifyUserById = <
+  TData = Awaited<ReturnType<typeof modifyUserById>>,
+  TError = ErrorType<HTTPException | Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number; data: BodyType<UserModify> }, TContext>
+}): UseMutationResult<TData, TError, { userId: number; data: BodyType<UserModify> }, TContext> => {
+  const mutationOptions = getModifyUserByIdMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Remove User By Id
+ */
+export const removeUserById = (userId: number) => {
+  return orvalFetcher<void>({ url: `/api/user/by-id/${userId}`, method: 'DELETE' })
+}
+
+export const getRemoveUserByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof removeUserById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number }, TContext>
+}) => {
+  const mutationKey = ['removeUserById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof removeUserById>>, { userId: number }> = props => {
+    const { userId } = props ?? {}
+
+    return removeUserById(userId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { userId: number }, TContext>
+}
+
+export type RemoveUserByIdMutationResult = NonNullable<Awaited<ReturnType<typeof removeUserById>>>
+
+export type RemoveUserByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Remove User By Id
+ */
+export const useRemoveUserById = <TData = Awaited<ReturnType<typeof removeUserById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number }, TContext>
+}): UseMutationResult<TData, TError, { userId: number }, TContext> => {
+  const mutationOptions = getRemoveUserByIdMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Get User By Id
+ */
+export const getUserById = (userId: number, signal?: AbortSignal) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-id/${userId}`, method: 'GET', signal })
+}
+
+export const getGetUserByIdQueryKey = (userId: number) => {
+  return [`/api/user/by-id/${userId}`] as const
+}
+
+export const getGetUserByIdQueryOptions = <TData = Awaited<ReturnType<typeof getUserById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserById>>, TError, TData>> },
+) => {
+  const { query: queryOptions } = options ?? {}
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserByIdQueryKey(userId)
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserById>>> = ({ signal }) => getUserById(userId, signal)
+
+  return { queryKey, queryFn, enabled: !!userId, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof getUserById>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type GetUserByIdQueryResult = NonNullable<Awaited<ReturnType<typeof getUserById>>>
+export type GetUserByIdQueryError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+export function useGetUserById<TData = Awaited<ReturnType<typeof getUserById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserById>>, TError, TData>> & Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof getUserById>>, TError, TData>, 'initialData'>
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserById<TData = Awaited<ReturnType<typeof getUserById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserById>>, TError, TData>> & Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof getUserById>>, TError, TData>, 'initialData'>
+  },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserById<TData = Awaited<ReturnType<typeof getUserById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserById>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get User By Id
+ */
+
+export function useGetUserById<TData = Awaited<ReturnType<typeof getUserById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserById>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetUserByIdQueryOptions(userId, options)
+
+  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  query.queryKey = queryOptions.queryKey
+
+  return query
+}
+
+/**
  * Reset user data usage
  * @summary Reset User Data Usage
  */
@@ -7950,6 +9031,104 @@ export const useResetUserDataUsage = <
   mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
 }): UseMutationResult<TData, TError, { username: string }, TContext> => {
   const mutationOptions = getResetUserDataUsageMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Reset User Data Usage By Username
+ */
+export const resetUserDataUsageByUsername = (username: string, signal?: AbortSignal) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-username/${username}/reset`, method: 'POST', signal })
+}
+
+export const getResetUserDataUsageByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof resetUserDataUsageByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['resetUserDataUsageByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof resetUserDataUsageByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return resetUserDataUsageByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type ResetUserDataUsageByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof resetUserDataUsageByUsername>>>
+
+export type ResetUserDataUsageByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Reset User Data Usage By Username
+ */
+export const useResetUserDataUsageByUsername = <
+  TData = Awaited<ReturnType<typeof resetUserDataUsageByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getResetUserDataUsageByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Reset User Data Usage By Id
+ */
+export const resetUserDataUsageById = (userId: number, signal?: AbortSignal) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-id/${userId}/reset`, method: 'POST', signal })
+}
+
+export const getResetUserDataUsageByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof resetUserDataUsageById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number }, TContext>
+}) => {
+  const mutationKey = ['resetUserDataUsageById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof resetUserDataUsageById>>, { userId: number }> = props => {
+    const { userId } = props ?? {}
+
+    return resetUserDataUsageById(userId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { userId: number }, TContext>
+}
+
+export type ResetUserDataUsageByIdMutationResult = NonNullable<Awaited<ReturnType<typeof resetUserDataUsageById>>>
+
+export type ResetUserDataUsageByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Reset User Data Usage By Id
+ */
+export const useResetUserDataUsageById = <
+  TData = Awaited<ReturnType<typeof resetUserDataUsageById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number }, TContext>
+}): UseMutationResult<TData, TError, { userId: number }, TContext> => {
+  const mutationOptions = getResetUserDataUsageByIdMutationOptions(options)
 
   return useMutation(mutationOptions)
 }
@@ -8005,6 +9184,104 @@ export const useRevokeUserSubscription = <
 }
 
 /**
+ * @summary Revoke User Subscription By Username
+ */
+export const revokeUserSubscriptionByUsername = (username: string, signal?: AbortSignal) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-username/${username}/revoke_sub`, method: 'POST', signal })
+}
+
+export const getRevokeUserSubscriptionByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof revokeUserSubscriptionByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['revokeUserSubscriptionByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof revokeUserSubscriptionByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return revokeUserSubscriptionByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type RevokeUserSubscriptionByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof revokeUserSubscriptionByUsername>>>
+
+export type RevokeUserSubscriptionByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Revoke User Subscription By Username
+ */
+export const useRevokeUserSubscriptionByUsername = <
+  TData = Awaited<ReturnType<typeof revokeUserSubscriptionByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getRevokeUserSubscriptionByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Revoke User Subscription By Id
+ */
+export const revokeUserSubscriptionById = (userId: number, signal?: AbortSignal) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-id/${userId}/revoke_sub`, method: 'POST', signal })
+}
+
+export const getRevokeUserSubscriptionByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof revokeUserSubscriptionById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number }, TContext>
+}) => {
+  const mutationKey = ['revokeUserSubscriptionById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof revokeUserSubscriptionById>>, { userId: number }> = props => {
+    const { userId } = props ?? {}
+
+    return revokeUserSubscriptionById(userId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { userId: number }, TContext>
+}
+
+export type RevokeUserSubscriptionByIdMutationResult = NonNullable<Awaited<ReturnType<typeof revokeUserSubscriptionById>>>
+
+export type RevokeUserSubscriptionByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Revoke User Subscription By Id
+ */
+export const useRevokeUserSubscriptionById = <
+  TData = Awaited<ReturnType<typeof revokeUserSubscriptionById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number }, TContext>
+}): UseMutationResult<TData, TError, { userId: number }, TContext> => {
+  const mutationOptions = getRevokeUserSubscriptionByIdMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
  * Reset all users data usage
  * @summary Reset Users Data Usage
  */
@@ -8045,7 +9322,7 @@ export const useResetUsersDataUsage = <TData = Awaited<ReturnType<typeof resetUs
 }
 
 /**
- * Get subscription agent distribution percentages (optionally filtered by username)
+ * Get subscription agent distribution percentages (optionally filtered by user_id/username).
  * @summary Get Users Sub Update Chart
  */
 export const getUsersSubUpdateChart = (params?: GetUsersSubUpdateChartParams, signal?: AbortSignal) => {
@@ -8150,6 +9427,92 @@ export const useSetOwner = <TData = Awaited<ReturnType<typeof setOwner>>, TError
 }
 
 /**
+ * @summary Set Owner By Username
+ */
+export const setOwnerByUsername = (username: string, params: SetOwnerByUsernameParams) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-username/${username}/set_owner`, method: 'PUT', params })
+}
+
+export const getSetOwnerByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof setOwnerByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; params: SetOwnerByUsernameParams }, TContext>
+}) => {
+  const mutationKey = ['setOwnerByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof setOwnerByUsername>>, { username: string; params: SetOwnerByUsernameParams }> = props => {
+    const { username, params } = props ?? {}
+
+    return setOwnerByUsername(username, params)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string; params: SetOwnerByUsernameParams }, TContext>
+}
+
+export type SetOwnerByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof setOwnerByUsername>>>
+
+export type SetOwnerByUsernameMutationError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>
+
+/**
+ * @summary Set Owner By Username
+ */
+export const useSetOwnerByUsername = <TData = Awaited<ReturnType<typeof setOwnerByUsername>>, TError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; params: SetOwnerByUsernameParams }, TContext>
+}): UseMutationResult<TData, TError, { username: string; params: SetOwnerByUsernameParams }, TContext> => {
+  const mutationOptions = getSetOwnerByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Set Owner By Id
+ */
+export const setOwnerById = (userId: number, params: SetOwnerByIdParams) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-id/${userId}/set_owner`, method: 'PUT', params })
+}
+
+export const getSetOwnerByIdMutationOptions = <TData = Awaited<ReturnType<typeof setOwnerById>>, TError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number; params: SetOwnerByIdParams }, TContext>
+}) => {
+  const mutationKey = ['setOwnerById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof setOwnerById>>, { userId: number; params: SetOwnerByIdParams }> = props => {
+    const { userId, params } = props ?? {}
+
+    return setOwnerById(userId, params)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { userId: number; params: SetOwnerByIdParams }, TContext>
+}
+
+export type SetOwnerByIdMutationResult = NonNullable<Awaited<ReturnType<typeof setOwnerById>>>
+
+export type SetOwnerByIdMutationError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>
+
+/**
+ * @summary Set Owner By Id
+ */
+export const useSetOwnerById = <TData = Awaited<ReturnType<typeof setOwnerById>>, TError = ErrorType<Unauthorized | Forbidden | HTTPValidationError>, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number; params: SetOwnerByIdParams }, TContext>
+}): UseMutationResult<TData, TError, { userId: number; params: SetOwnerByIdParams }, TContext> => {
+  const mutationOptions = getSetOwnerByIdMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
  * Reset user by next plan
  * @summary Active Next Plan
  */
@@ -8191,6 +9554,104 @@ export const useActiveNextPlan = <TData = Awaited<ReturnType<typeof activeNextPl
   mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
 }): UseMutationResult<TData, TError, { username: string }, TContext> => {
   const mutationOptions = getActiveNextPlanMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Active Next Plan By Username
+ */
+export const activeNextPlanByUsername = (username: string, signal?: AbortSignal) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-username/${username}/active_next`, method: 'POST', signal })
+}
+
+export const getActiveNextPlanByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof activeNextPlanByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}) => {
+  const mutationKey = ['activeNextPlanByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof activeNextPlanByUsername>>, { username: string }> = props => {
+    const { username } = props ?? {}
+
+    return activeNextPlanByUsername(username)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string }, TContext>
+}
+
+export type ActiveNextPlanByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof activeNextPlanByUsername>>>
+
+export type ActiveNextPlanByUsernameMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Active Next Plan By Username
+ */
+export const useActiveNextPlanByUsername = <
+  TData = Awaited<ReturnType<typeof activeNextPlanByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string }, TContext>
+}): UseMutationResult<TData, TError, { username: string }, TContext> => {
+  const mutationOptions = getActiveNextPlanByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Active Next Plan By Id
+ */
+export const activeNextPlanById = (userId: number, signal?: AbortSignal) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/by-id/${userId}/active_next`, method: 'POST', signal })
+}
+
+export const getActiveNextPlanByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof activeNextPlanById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number }, TContext>
+}) => {
+  const mutationKey = ['activeNextPlanById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof activeNextPlanById>>, { userId: number }> = props => {
+    const { userId } = props ?? {}
+
+    return activeNextPlanById(userId)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { userId: number }, TContext>
+}
+
+export type ActiveNextPlanByIdMutationResult = NonNullable<Awaited<ReturnType<typeof activeNextPlanById>>>
+
+export type ActiveNextPlanByIdMutationError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+/**
+ * @summary Active Next Plan By Id
+ */
+export const useActiveNextPlanById = <
+  TData = Awaited<ReturnType<typeof activeNextPlanById>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number }, TContext>
+}): UseMutationResult<TData, TError, { userId: number }, TContext> => {
+  const mutationOptions = getActiveNextPlanByIdMutationOptions(options)
 
   return useMutation(mutationOptions)
 }
@@ -8257,6 +9718,147 @@ export function useGetUserSubUpdateList<TData = Awaited<ReturnType<typeof getUse
   options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateList>>, TError, TData>> },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getGetUserSubUpdateListQueryOptions(username, params, options)
+
+  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  query.queryKey = queryOptions.queryKey
+
+  return query
+}
+
+/**
+ * @summary Get User Sub Update List By Username
+ */
+export const getUserSubUpdateListByUsername = (username: string, params?: GetUserSubUpdateListByUsernameParams, signal?: AbortSignal) => {
+  return orvalFetcher<UserSubscriptionUpdateList>({ url: `/api/user/by-username/${username}/sub_update`, method: 'GET', params, signal })
+}
+
+export const getGetUserSubUpdateListByUsernameQueryKey = (username: string, params?: GetUserSubUpdateListByUsernameParams) => {
+  return [`/api/user/by-username/${username}/sub_update`, ...(params ? [params] : [])] as const
+}
+
+export const getGetUserSubUpdateListByUsernameQueryOptions = <
+  TData = Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>,
+  TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>,
+>(
+  username: string,
+  params?: GetUserSubUpdateListByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError, TData>> },
+) => {
+  const { query: queryOptions } = options ?? {}
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserSubUpdateListByUsernameQueryKey(username, params)
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>> = ({ signal }) => getUserSubUpdateListByUsername(username, params, signal)
+
+  return { queryKey, queryFn, enabled: !!username, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData, TError>
+  }
+}
+
+export type GetUserSubUpdateListByUsernameQueryResult = NonNullable<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>>
+export type GetUserSubUpdateListByUsernameQueryError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+export function useGetUserSubUpdateListByUsername<TData = Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: undefined | GetUserSubUpdateListByUsernameParams,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError, TData>> &
+      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError, TData>, 'initialData'>
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserSubUpdateListByUsername<TData = Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params?: GetUserSubUpdateListByUsernameParams,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError, TData>, 'initialData'>
+  },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserSubUpdateListByUsername<TData = Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params?: GetUserSubUpdateListByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get User Sub Update List By Username
+ */
+
+export function useGetUserSubUpdateListByUsername<TData = Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params?: GetUserSubUpdateListByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListByUsername>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetUserSubUpdateListByUsernameQueryOptions(username, params, options)
+
+  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  query.queryKey = queryOptions.queryKey
+
+  return query
+}
+
+/**
+ * @summary Get User Sub Update List By Id
+ */
+export const getUserSubUpdateListById = (userId: number, params?: GetUserSubUpdateListByIdParams, signal?: AbortSignal) => {
+  return orvalFetcher<UserSubscriptionUpdateList>({ url: `/api/user/by-id/${userId}/sub_update`, method: 'GET', params, signal })
+}
+
+export const getGetUserSubUpdateListByIdQueryKey = (userId: number, params?: GetUserSubUpdateListByIdParams) => {
+  return [`/api/user/by-id/${userId}/sub_update`, ...(params ? [params] : [])] as const
+}
+
+export const getGetUserSubUpdateListByIdQueryOptions = <TData = Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params?: GetUserSubUpdateListByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError, TData>> },
+) => {
+  const { query: queryOptions } = options ?? {}
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserSubUpdateListByIdQueryKey(userId, params)
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserSubUpdateListById>>> = ({ signal }) => getUserSubUpdateListById(userId, params, signal)
+
+  return { queryKey, queryFn, enabled: !!userId, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData, TError>
+  }
+}
+
+export type GetUserSubUpdateListByIdQueryResult = NonNullable<Awaited<ReturnType<typeof getUserSubUpdateListById>>>
+export type GetUserSubUpdateListByIdQueryError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+export function useGetUserSubUpdateListById<TData = Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params: undefined | GetUserSubUpdateListByIdParams,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError, TData>> &
+      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError, TData>, 'initialData'>
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserSubUpdateListById<TData = Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params?: GetUserSubUpdateListByIdParams,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError, TData>, 'initialData'>
+  },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserSubUpdateListById<TData = Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params?: GetUserSubUpdateListByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get User Sub Update List By Id
+ */
+
+export function useGetUserSubUpdateListById<TData = Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params?: GetUserSubUpdateListByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserSubUpdateListById>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetUserSubUpdateListByIdQueryOptions(userId, params, options)
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 
@@ -8448,6 +10050,142 @@ export function useGetUserUsage<TData = Awaited<ReturnType<typeof getUserUsage>>
   options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsage>>, TError, TData>> },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getGetUserUsageQueryOptions(username, params, options)
+
+  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  query.queryKey = queryOptions.queryKey
+
+  return query
+}
+
+/**
+ * @summary Get User Usage By Username
+ */
+export const getUserUsageByUsername = (username: string, params: GetUserUsageByUsernameParams, signal?: AbortSignal) => {
+  return orvalFetcher<UserUsageStatsList>({ url: `/api/user/by-username/${username}/usage`, method: 'GET', params, signal })
+}
+
+export const getGetUserUsageByUsernameQueryKey = (username: string, params: GetUserUsageByUsernameParams) => {
+  return [`/api/user/by-username/${username}/usage`, ...(params ? [params] : [])] as const
+}
+
+export const getGetUserUsageByUsernameQueryOptions = <TData = Awaited<ReturnType<typeof getUserUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetUserUsageByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageByUsername>>, TError, TData>> },
+) => {
+  const { query: queryOptions } = options ?? {}
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserUsageByUsernameQueryKey(username, params)
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserUsageByUsername>>> = ({ signal }) => getUserUsageByUsername(username, params, signal)
+
+  return { queryKey, queryFn, enabled: !!username, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof getUserUsageByUsername>>, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData, TError>
+  }
+}
+
+export type GetUserUsageByUsernameQueryResult = NonNullable<Awaited<ReturnType<typeof getUserUsageByUsername>>>
+export type GetUserUsageByUsernameQueryError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+export function useGetUserUsageByUsername<TData = Awaited<ReturnType<typeof getUserUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetUserUsageByUsernameParams,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageByUsername>>, TError, TData>> &
+      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof getUserUsageByUsername>>, TError, TData>, 'initialData'>
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserUsageByUsername<TData = Awaited<ReturnType<typeof getUserUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetUserUsageByUsernameParams,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageByUsername>>, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof getUserUsageByUsername>>, TError, TData>, 'initialData'>
+  },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserUsageByUsername<TData = Awaited<ReturnType<typeof getUserUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetUserUsageByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageByUsername>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get User Usage By Username
+ */
+
+export function useGetUserUsageByUsername<TData = Awaited<ReturnType<typeof getUserUsageByUsername>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  username: string,
+  params: GetUserUsageByUsernameParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageByUsername>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetUserUsageByUsernameQueryOptions(username, params, options)
+
+  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  query.queryKey = queryOptions.queryKey
+
+  return query
+}
+
+/**
+ * @summary Get User Usage By Id
+ */
+export const getUserUsageById = (userId: number, params: GetUserUsageByIdParams, signal?: AbortSignal) => {
+  return orvalFetcher<UserUsageStatsList>({ url: `/api/user/by-id/${userId}/usage`, method: 'GET', params, signal })
+}
+
+export const getGetUserUsageByIdQueryKey = (userId: number, params: GetUserUsageByIdParams) => {
+  return [`/api/user/by-id/${userId}/usage`, ...(params ? [params] : [])] as const
+}
+
+export const getGetUserUsageByIdQueryOptions = <TData = Awaited<ReturnType<typeof getUserUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params: GetUserUsageByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageById>>, TError, TData>> },
+) => {
+  const { query: queryOptions } = options ?? {}
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserUsageByIdQueryKey(userId, params)
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserUsageById>>> = ({ signal }) => getUserUsageById(userId, params, signal)
+
+  return { queryKey, queryFn, enabled: !!userId, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof getUserUsageById>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type GetUserUsageByIdQueryResult = NonNullable<Awaited<ReturnType<typeof getUserUsageById>>>
+export type GetUserUsageByIdQueryError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>
+
+export function useGetUserUsageById<TData = Awaited<ReturnType<typeof getUserUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params: GetUserUsageByIdParams,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageById>>, TError, TData>> &
+      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof getUserUsageById>>, TError, TData>, 'initialData'>
+  },
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserUsageById<TData = Awaited<ReturnType<typeof getUserUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params: GetUserUsageByIdParams,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageById>>, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof getUserUsageById>>, TError, TData>, 'initialData'>
+  },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useGetUserUsageById<TData = Awaited<ReturnType<typeof getUserUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params: GetUserUsageByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageById>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get User Usage By Id
+ */
+
+export function useGetUserUsageById<TData = Awaited<ReturnType<typeof getUserUsageById>>, TError = ErrorType<Unauthorized | Forbidden | NotFound | HTTPValidationError>>(
+  userId: number,
+  params: GetUserUsageByIdParams,
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserUsageById>>, TError, TData>> },
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetUserUsageByIdQueryOptions(userId, params, options)
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 
@@ -9125,6 +10863,100 @@ export const useModifyUserWithTemplate = <TData = Awaited<ReturnType<typeof modi
   mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<ModifyUserByTemplate> }, TContext>
 }): UseMutationResult<TData, TError, { username: string; data: BodyType<ModifyUserByTemplate> }, TContext> => {
   const mutationOptions = getModifyUserWithTemplateMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Modify User With Template By Username
+ */
+export const modifyUserWithTemplateByUsername = (username: string, modifyUserByTemplate: BodyType<ModifyUserByTemplate>) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/from_template/by-username/${username}`, method: 'PUT', headers: { 'Content-Type': 'application/json' }, data: modifyUserByTemplate })
+}
+
+export const getModifyUserWithTemplateByUsernameMutationOptions = <
+  TData = Awaited<ReturnType<typeof modifyUserWithTemplateByUsername>>,
+  TError = ErrorType<Unauthorized | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<ModifyUserByTemplate> }, TContext>
+}) => {
+  const mutationKey = ['modifyUserWithTemplateByUsername']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof modifyUserWithTemplateByUsername>>, { username: string; data: BodyType<ModifyUserByTemplate> }> = props => {
+    const { username, data } = props ?? {}
+
+    return modifyUserWithTemplateByUsername(username, data)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { username: string; data: BodyType<ModifyUserByTemplate> }, TContext>
+}
+
+export type ModifyUserWithTemplateByUsernameMutationResult = NonNullable<Awaited<ReturnType<typeof modifyUserWithTemplateByUsername>>>
+export type ModifyUserWithTemplateByUsernameMutationBody = BodyType<ModifyUserByTemplate>
+export type ModifyUserWithTemplateByUsernameMutationError = ErrorType<Unauthorized | HTTPValidationError>
+
+/**
+ * @summary Modify User With Template By Username
+ */
+export const useModifyUserWithTemplateByUsername = <
+  TData = Awaited<ReturnType<typeof modifyUserWithTemplateByUsername>>,
+  TError = ErrorType<Unauthorized | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { username: string; data: BodyType<ModifyUserByTemplate> }, TContext>
+}): UseMutationResult<TData, TError, { username: string; data: BodyType<ModifyUserByTemplate> }, TContext> => {
+  const mutationOptions = getModifyUserWithTemplateByUsernameMutationOptions(options)
+
+  return useMutation(mutationOptions)
+}
+
+/**
+ * @summary Modify User With Template By Id
+ */
+export const modifyUserWithTemplateById = (userId: number, modifyUserByTemplate: BodyType<ModifyUserByTemplate>) => {
+  return orvalFetcher<UserResponse>({ url: `/api/user/from_template/by-id/${userId}`, method: 'PUT', headers: { 'Content-Type': 'application/json' }, data: modifyUserByTemplate })
+}
+
+export const getModifyUserWithTemplateByIdMutationOptions = <
+  TData = Awaited<ReturnType<typeof modifyUserWithTemplateById>>,
+  TError = ErrorType<Unauthorized | HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number; data: BodyType<ModifyUserByTemplate> }, TContext>
+}) => {
+  const mutationKey = ['modifyUserWithTemplateById']
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } }
+
+  const mutationFn: MutationFunction<Awaited<ReturnType<typeof modifyUserWithTemplateById>>, { userId: number; data: BodyType<ModifyUserByTemplate> }> = props => {
+    const { userId, data } = props ?? {}
+
+    return modifyUserWithTemplateById(userId, data)
+  }
+
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<TData, TError, { userId: number; data: BodyType<ModifyUserByTemplate> }, TContext>
+}
+
+export type ModifyUserWithTemplateByIdMutationResult = NonNullable<Awaited<ReturnType<typeof modifyUserWithTemplateById>>>
+export type ModifyUserWithTemplateByIdMutationBody = BodyType<ModifyUserByTemplate>
+export type ModifyUserWithTemplateByIdMutationError = ErrorType<Unauthorized | HTTPValidationError>
+
+/**
+ * @summary Modify User With Template By Id
+ */
+export const useModifyUserWithTemplateById = <TData = Awaited<ReturnType<typeof modifyUserWithTemplateById>>, TError = ErrorType<Unauthorized | HTTPValidationError>, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<TData, TError, { userId: number; data: BodyType<ModifyUserByTemplate> }, TContext>
+}): UseMutationResult<TData, TError, { userId: number; data: BodyType<ModifyUserByTemplate> }, TContext> => {
+  const mutationOptions = getModifyUserWithTemplateByIdMutationOptions(options)
 
   return useMutation(mutationOptions)
 }

--- a/dashboard/src/utils/adminsCache.ts
+++ b/dashboard/src/utils/adminsCache.ts
@@ -38,6 +38,14 @@ const includesIgnoreCase = (value: string | null | undefined, needle: string): b
 
 const isDisabled = (admin: AdminDetails): boolean => !!admin.is_disabled
 
+const sameAdmin = (left: AdminDetails, right: AdminDetails): boolean => {
+  if (left.id != null && right.id != null) {
+    return left.id === right.id
+  }
+
+  return left.username === right.username
+}
+
 const getCreatedAt = (admin: AdminDetails): unknown => {
   return (admin as AdminDetails & { created_at?: string | number | null }).created_at
 }
@@ -101,7 +109,7 @@ const incrementStatusCount = (active: number, disabled: number, admin: AdminDeta
 
 const upsertInSingleAdminsQuery = (oldData: AdminsResponse, admin: AdminDetails, params: GetAdminsParams | undefined, allowInsert: boolean): AdminsResponse | undefined => {
   const oldAdmins = oldData.admins ?? []
-  const existingIndex = oldAdmins.findIndex(a => a.username === admin.username)
+  const existingIndex = oldAdmins.findIndex(a => sameAdmin(a, admin))
   const matchesFilters = matchesAdminFilters(admin, params)
 
   let admins = oldAdmins
@@ -114,7 +122,7 @@ const upsertInSingleAdminsQuery = (oldData: AdminsResponse, admin: AdminDetails,
     const previous = oldAdmins[existingIndex]
 
     if (matchesFilters) {
-      admins = oldAdmins.map(a => (a.username === admin.username ? admin : a))
+      admins = oldAdmins.map(a => (sameAdmin(a, admin) ? admin : a))
       changed = true
 
       if (isDisabled(previous) !== isDisabled(admin)) {
@@ -127,7 +135,7 @@ const upsertInSingleAdminsQuery = (oldData: AdminsResponse, admin: AdminDetails,
         }
       }
     } else {
-      admins = oldAdmins.filter(a => a.username !== admin.username)
+      admins = oldAdmins.filter(a => !sameAdmin(a, admin))
       total = Math.max(0, total - 1)
       const dec = decrementStatusCount(active, disabled, previous)
       active = dec.active
@@ -186,7 +194,7 @@ export const upsertAdminInAdminsCache = (queryClient: QueryClient, admin: AdminD
   })
 }
 
-export const removeAdminFromAdminsCache = (queryClient: QueryClient, username: string) => {
+export const removeAdminFromAdminsCache = (queryClient: QueryClient, adminId: number) => {
   const cachedQueries = queryClient.getQueriesData<AdminsResponse>({
     queryKey: [ADMINS_QUERY_KEY],
     exact: false,
@@ -194,10 +202,10 @@ export const removeAdminFromAdminsCache = (queryClient: QueryClient, username: s
 
   cachedQueries.forEach(([queryKey, oldData]) => {
     if (!oldData) return
-    const existing = oldData.admins.find(a => a.username === username)
+    const existing = oldData.admins.find(a => a.id === adminId)
     if (!existing) return
 
-    const admins = oldData.admins.filter(a => a.username !== username)
+    const admins = oldData.admins.filter(a => a.id !== adminId)
     const total = Math.max(0, oldData.total - 1)
     const dec = decrementStatusCount(oldData.active, oldData.disabled, existing)
 
@@ -211,7 +219,7 @@ export const removeAdminFromAdminsCache = (queryClient: QueryClient, username: s
   })
 }
 
-export const patchAdminInAdminsCache = (queryClient: QueryClient, username: string, patch: Partial<AdminDetails>) => {
+export const patchAdminInAdminsCache = (queryClient: QueryClient, adminId: number, patch: Partial<AdminDetails>) => {
   const cachedQueries = queryClient.getQueriesData<AdminsResponse>({
     queryKey: [ADMINS_QUERY_KEY],
     exact: false,
@@ -219,12 +227,12 @@ export const patchAdminInAdminsCache = (queryClient: QueryClient, username: stri
 
   cachedQueries.forEach(([queryKey, oldData]) => {
     if (!oldData) return
-    const index = oldData.admins.findIndex(a => a.username === username)
+    const index = oldData.admins.findIndex(a => a.id === adminId)
     if (index < 0) return
 
     const oldAdmin = oldData.admins[index]
     const updatedAdmin = { ...oldAdmin, ...patch }
-    const admins = oldData.admins.map(a => (a.username === username ? updatedAdmin : a))
+    const admins = oldData.admins.map(a => (a.id === adminId ? updatedAdmin : a))
 
     let active = oldData.active
     let disabled = oldData.disabled

--- a/dashboard/src/utils/usersCache.ts
+++ b/dashboard/src/utils/usersCache.ts
@@ -144,7 +144,7 @@ const shouldInsertIntoQueryPage = (params?: GetUsersParams): boolean => {
 
 const upsertInSingleUsersQuery = (oldData: UsersResponse, user: UserResponse, params: GetUsersParams | undefined, allowInsert: boolean): UsersResponse | undefined => {
   const oldUsers = oldData.users ?? []
-  const existingIndex = oldUsers.findIndex(u => u.username === user.username)
+  const existingIndex = oldUsers.findIndex(u => u.id === user.id)
   const matchesFilters = matchesUserFilters(user, params)
 
   let users = oldUsers
@@ -153,10 +153,10 @@ const upsertInSingleUsersQuery = (oldData: UsersResponse, user: UserResponse, pa
 
   if (existingIndex >= 0) {
     if (matchesFilters) {
-      users = oldUsers.map(u => (u.username === user.username ? user : u))
+      users = oldUsers.map(u => (u.id === user.id ? user : u))
       changed = true
     } else {
-      users = oldUsers.filter(u => u.username !== user.username)
+      users = oldUsers.filter(u => u.id !== user.id)
       total = Math.max(0, total - 1)
       changed = true
     }

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -12,6 +12,7 @@ from app.db.crud.admin import get_admin_by_telegram_id
 from app.db.models import Admin, AdminUsageLogs, NodeUserUsage
 from app.models.settings import RunMethod, Telegram
 from app.routers.authentication import validate_mini_app_admin
+from app.utils.jwt import get_admin_payload
 from tests.api import TestSession, client
 from tests.api.helpers import (
     auth_headers,
@@ -78,6 +79,23 @@ def test_admin_login():
     assert response.status_code == status.HTTP_200_OK
     assert "access_token" in response.json()
     return response.json()["access_token"]
+
+
+def test_admin_token_contains_admin_id_claim(access_token):
+    admin = create_admin(access_token)
+    try:
+        response = client.post(
+            url="/api/admin/token",
+            data={"username": admin["username"], "password": admin["password"], "grant_type": "password"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        token = response.json()["access_token"]
+        payload = asyncio.run(get_admin_payload(token))
+        assert payload is not None
+        assert payload["admin_id"] == admin["id"]
+        assert payload["username"] == admin["username"]
+    finally:
+        delete_admin(access_token, admin["username"])
 
 
 def test_get_admin(access_token):
@@ -262,6 +280,41 @@ def test_update_admin(access_token):
     assert response.json()["is_sudo"] is False
     assert response.json()["is_disabled"] is True
     delete_admin(access_token, admin["username"])
+
+
+def test_admin_routes_by_id_and_by_username(access_token):
+    admin = create_admin(access_token)
+    try:
+        by_username_update = client.put(
+            url=f"/api/admin/by-username/{admin['username']}",
+            json={"is_sudo": False, "note": "by-username note"},
+            headers=auth_headers(access_token),
+        )
+        assert by_username_update.status_code == status.HTTP_200_OK
+        assert by_username_update.json()["note"] == "by-username note"
+
+        by_id_update = client.put(
+            url=f"/api/admin/by-id/{admin['id']}",
+            json={"is_sudo": False, "note": "by-id note"},
+            headers=auth_headers(access_token),
+        )
+        assert by_id_update.status_code == status.HTTP_200_OK
+        assert by_id_update.json()["note"] == "by-id note"
+
+        by_id_usage = client.get(
+            f"/api/admin/by-id/{admin['id']}/usage",
+            headers=auth_headers(access_token),
+            params={"period": "hour"},
+        )
+        assert by_id_usage.status_code == status.HTTP_200_OK
+
+        by_username_reset = client.post(
+            f"/api/admin/by-username/{admin['username']}/reset",
+            headers=auth_headers(access_token),
+        )
+        assert by_username_reset.status_code == status.HTTP_200_OK
+    finally:
+        delete_admin(access_token, admin["username"])
 
 
 def test_update_admin_note(access_token):

--- a/tests/api/test_user.py
+++ b/tests/api/test_user.py
@@ -1,8 +1,13 @@
 import io
 import json
 import zipfile
+from base64 import b64encode
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from math import ceil
+import asyncio
+import time
 from urllib.parse import parse_qs, unquote, urlsplit
 
 from fastapi import status
@@ -10,6 +15,7 @@ from fastapi import status
 from app.models.settings import ConfigFormat, SubRule
 from app.operation.subscription import SubscriptionOperation
 from app.utils.crypto import generate_wireguard_keypair, get_wireguard_public_key
+from app.utils.jwt import get_secret_key
 from tests.api import client
 from tests.api.helpers import (
     auth_headers,
@@ -44,6 +50,15 @@ def extract_wireguard_config_bodies(response) -> list[str]:
     with zipfile.ZipFile(io.BytesIO(response.content)) as zip_file:
         config_files = [name for name in zip_file.namelist() if name.endswith(".conf")]
         return [zip_file.read(name).decode("utf-8") for name in config_files]
+
+
+def _build_legacy_subscription_token(username: str) -> str:
+    created_at = str(ceil(time.time()))
+    data = f"{username},{created_at}"
+    data_b64 = b64encode(data.encode("utf-8"), altchars=b"-_").decode("utf-8").rstrip("=")
+    secret = asyncio.run(get_secret_key())
+    sign = b64encode(sha256((data_b64 + secret).encode("utf-8")).digest(), altchars=b"-_").decode("utf-8")[:10]
+    return data_b64 + sign
 
 
 def test_user_create_active(access_token):
@@ -194,6 +209,62 @@ def test_user_subscriptions(access_token):
         delete_user(access_token, user["username"])
         for host in hosts:
             client.delete(f"/api/host/{host['id']}", headers={"Authorization": f"Bearer {access_token}"})
+        cleanup_groups(access_token, core, groups)
+
+
+def test_user_routes_by_id_and_by_username(access_token):
+    core, groups = setup_groups(access_token, 1)
+    user = create_user(access_token, group_ids=[groups[0]["id"]], payload={"username": unique_name("id_routes_user")})
+    try:
+        by_id_get = client.get(f"/api/user/by-id/{user['id']}", headers=auth_headers(access_token))
+        assert by_id_get.status_code == status.HTTP_200_OK
+        assert by_id_get.json()["username"] == user["username"]
+
+        by_username_get = client.get(f"/api/user/by-username/{user['username']}", headers=auth_headers(access_token))
+        assert by_username_get.status_code == status.HTTP_200_OK
+        assert by_username_get.json()["id"] == user["id"]
+
+        patch_payload = {"note": "updated via by-id"}
+        by_id_modify = client.put(
+            f"/api/user/by-id/{user['id']}",
+            headers=auth_headers(access_token),
+            json=patch_payload,
+        )
+        assert by_id_modify.status_code == status.HTTP_200_OK
+        assert by_id_modify.json()["note"] == patch_payload["note"]
+
+        by_username_usage = client.get(
+            f"/api/user/by-username/{user['username']}/usage",
+            headers=auth_headers(access_token),
+            params={"period": "hour"},
+        )
+        assert by_username_usage.status_code == status.HTTP_200_OK
+    finally:
+        delete_user(access_token, user["username"])
+        cleanup_groups(access_token, core, groups)
+
+
+def test_subscription_url_new_token_and_legacy_compatibility(access_token):
+    core, groups = setup_groups(access_token, 1)
+    hosts = create_hosts_for_inbounds(access_token)
+    user = create_user(
+        access_token,
+        group_ids=[group["id"] for group in groups],
+        payload={"username": unique_name("legacy_sub_user")},
+    )
+    try:
+        current_token_url = user["subscription_url"]
+        current_links = client.get(f"{current_token_url}/links")
+        assert current_links.status_code == status.HTTP_200_OK
+
+        legacy_token = _build_legacy_subscription_token(user["username"])
+        legacy_token_url = f"{current_token_url.rsplit('/', 1)[0]}/{legacy_token}"
+        legacy_links = client.get(f"{legacy_token_url}/links")
+        assert legacy_links.status_code == status.HTTP_200_OK
+    finally:
+        delete_user(access_token, user["username"])
+        for host in hosts:
+            client.delete(f"/api/host/{host['id']}", headers=auth_headers(access_token))
         cleanup_groups(access_token, core, groups)
 
 

--- a/tui/admin.py
+++ b/tui/admin.py
@@ -30,6 +30,7 @@ class AdminDelete(BaseModal):
         self,
         db: AsyncSession,
         operation: AdminOperation,
+        admin_id: int,
         username: str,
         on_close: callable,
         user_count: int = 0,
@@ -39,6 +40,7 @@ class AdminDelete(BaseModal):
         super().__init__(*args, **kwargs)
         self.db = db
         self.operation = operation
+        self.admin_id = admin_id
         self.username = username
         self.on_close = on_close
         self.user_count = user_count
@@ -73,9 +75,9 @@ class AdminDelete(BaseModal):
                 if self.user_count > 0:
                     delete_users = self.query_one("#delete-users").value
                     if delete_users:
-                        await self.operation.remove_all_users(self.db, self.username, SYSTEM_ADMIN)
+                        await self.operation.remove_all_users_by_id(self.db, self.admin_id, SYSTEM_ADMIN)
                         self.notify("Admin users deleted successfully", severity="success", title="Success")
-                await self.operation.remove_admin(self.db, self.username, SYSTEM_ADMIN)
+                await self.operation.remove_admin_by_id(self.db, self.admin_id, SYSTEM_ADMIN)
                 self.on_close()
             except ValueError as e:
                 self.notify(str(e), severity="error", title="Error")
@@ -87,6 +89,7 @@ class AdminDeleteUsers(BaseModal):
         self,
         db: AsyncSession,
         operation: AdminOperation,
+        admin_id: int,
         username: str,
         on_close: callable,
         user_count: int = 0,
@@ -96,6 +99,7 @@ class AdminDeleteUsers(BaseModal):
         super().__init__(*args, **kwargs)
         self.db = db
         self.operation = operation
+        self.admin_id = admin_id
         self.username = username
         self.on_close = on_close
         self.user_count = user_count
@@ -120,7 +124,7 @@ class AdminDeleteUsers(BaseModal):
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "delete":
             try:
-                deleted = await self.operation.remove_all_users(self.db, self.username, SYSTEM_ADMIN)
+                deleted = await self.operation.remove_all_users_by_id(self.db, self.admin_id, SYSTEM_ADMIN)
                 if deleted == 0:
                     self.notify("No users were deleted (none found)", severity="warning", title="Info")
                 else:
@@ -135,11 +139,19 @@ class AdminDeleteUsers(BaseModal):
 
 class AdminResetUsage(BaseModal):
     def __init__(
-        self, db: AsyncSession, operation: AdminOperation, username: str, on_close: callable, *args, **kwargs
+        self,
+        db: AsyncSession,
+        operation: AdminOperation,
+        admin_id: int,
+        username: str,
+        on_close: callable,
+        *args,
+        **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.db = db
         self.operation = operation
+        self.admin_id = admin_id
         self.username = username
         self.on_close = on_close
 
@@ -160,7 +172,7 @@ class AdminResetUsage(BaseModal):
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "reset":
             try:
-                await self.operation.reset_admin_usage(self.db, self.username, SYSTEM_ADMIN)
+                await self.operation.reset_admin_usage_by_id(self.db, self.admin_id, SYSTEM_ADMIN)
                 self.notify("Admin usage reseted successfully", severity="success", title="Success")
                 self.on_close()
             except ValueError as e:
@@ -587,9 +599,9 @@ class AdminModifyModale(BaseModal):
                 self.notify("Password and confirm password do not match", severity="error", title="Error")
                 return
             try:
-                await self.operation.modify_admin(
+                await self.operation.modify_admin_by_id(
                     self.db,
-                    self.admin.username,
+                    self.admin.id,
                     AdminModify(
                         password=password,
                         telegram_id=telegram_id,
@@ -715,11 +727,11 @@ class AdminContent(Static):
         centered_columns = [self._center_text(column, column_widths[i]) for i, column in enumerate(columns)]
         self.table.add_columns(*centered_columns)
         i = 1
-        for row, adnin in zip(admins_data, admins):
+        for row, admin_obj in zip(admins_data, admins):
             centered_row = [self._center_text(str(cell), column_widths[i]) for i, cell in enumerate(row)]
             label = Text(f"{i + offset}")
             i += 1
-            self.table.add_row(*centered_row, key=adnin.username, label=label)
+            self.table.add_row(*centered_row, key=str(admin_obj.id), label=label)
 
         total_pages = (self.total_admins + self.page_size - 1) // self.page_size
         self.pagination_info.update(
@@ -727,25 +739,25 @@ class AdminContent(Static):
         )
 
     @property
-    def selected_admin(self):
-        return self.table.coordinate_to_cell_key(Coordinate(self.table.cursor_row, 0)).row_key.value
+    def selected_admin_id(self) -> int:
+        return int(self.table.coordinate_to_cell_key(Coordinate(self.table.cursor_row, 0)).row_key.value)
 
     async def action_delete_admin(self):
         if not self.table.columns:
             return
-        admin = await self.admin_operator.get_validated_admin(self.db, username=self.selected_admin)
+        admin = await self.admin_operator.get_validated_admin_by_id(self.db, self.selected_admin_id)
         user_count = len(admin.users or [])
         self.app.push_screen(
-            AdminDelete(self.db, self.admin_operator, self.selected_admin, self._refresh_table, user_count)
+            AdminDelete(self.db, self.admin_operator, admin.id, admin.username, self._refresh_table, user_count)
         )
 
     async def action_delete_admin_users(self):
         if not self.table.columns:
             return
-        admin = await self.admin_operator.get_validated_admin(self.db, username=self.selected_admin)
+        admin = await self.admin_operator.get_validated_admin_by_id(self.db, self.selected_admin_id)
         user_count = len(admin.users or [])
         self.app.push_screen(
-            AdminDeleteUsers(self.db, self.admin_operator, self.selected_admin, self._refresh_table, user_count)
+            AdminDeleteUsers(self.db, self.admin_operator, admin.id, admin.username, self._refresh_table, user_count)
         )
 
     def _refresh_table(self):
@@ -759,7 +771,7 @@ class AdminContent(Static):
     async def action_modify_admin(self):
         if not self.table.columns:
             return
-        admin = await self.admin_operator.get_validated_admin(self.db, username=self.selected_admin)
+        admin = await self.admin_operator.get_validated_admin_by_id(self.db, self.selected_admin_id)
         self.app.push_screen(
             AdminModifyModale(
                 self.db, self.admin_operator, admin, self._refresh_table, self.format_tui_validation_error
@@ -812,7 +824,8 @@ class AdminContent(Static):
     async def action_reset_admin_usage(self):
         if not self.table.columns:
             return
-        self.app.push_screen(AdminResetUsage(self.db, self.admin_operator, self.selected_admin, self._refresh_table))
+        admin = await self.admin_operator.get_validated_admin_by_id(self.db, self.selected_admin_id)
+        self.app.push_screen(AdminResetUsage(self.db, self.admin_operator, admin.id, admin.username, self._refresh_table))
 
     async def action_previous_page(self):
         if self.current_page > 1:


### PR DESCRIPTION
This PR adds ID-based API paths for user and admin operations while keeping the existing username-based routes available for compatibility.

Summary:
- Adds /by-id/... and /by-username/... routes for user and admin actions.
- Refactors user/admin operations to use shared internal helpers and adds deprecation warnings for username-based operation methods.
- Updates admin JWTs to include the admin ID claim and resolves authenticated admins by ID with username fallback.
- Updates subscription tokens to use user_id in the new token format while preserving legacy username token compatibility.
- Regenerates dashboard API hooks/types and updates dashboard user/admin actions, modals, usage charts, caches, CLI, and TUI flows to prefer IDs.
- Adds API tests for ID-based routes, admin token ID claims, and legacy subscription token compatibility.
