### PR TITLE
fix: resolve Pydantic 2.13 type mismatch for random_user_agent field

### DIFF
--- a/app/core/hosts.py
+++ b/app/core/hosts.py
@@ -254,7 +254,7 @@ async def _prepare_subscription_inbound_data(
             xmux=xs.xmux.model_dump(by_alias=True, exclude_none=True) if xs and xs.xmux else None,
             download_settings=down_settings if xs and down_settings else None,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=str(host.random_user_agent) if host.random_user_agent is not None else "",
         )
     elif network in ("grpc", "gun"):
         gs = ts.grpc_settings if ts else None
@@ -267,7 +267,7 @@ async def _prepare_subscription_inbound_data(
             permit_without_stream=gs.permit_without_stream if gs else False,
             initial_windows_size=gs.initial_windows_size if gs else None,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=str(host.random_user_agent) if host.random_user_agent is not None else "",
         )
     elif network == "kcp":
         ks = ts.kcp_settings if ts else None
@@ -311,7 +311,7 @@ async def _prepare_subscription_inbound_data(
             host=host_list,
             heartbeat_period=ws.heartbeatPeriod if ws else None,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=str(host.random_user_agent) if host.random_user_agent is not None else "",
         )
     elif network in ("tcp", "raw", "http", "h2"):
         # TCP/HTTP/H2 all use TCP transport
@@ -330,7 +330,7 @@ async def _prepare_subscription_inbound_data(
             request=tcps.request.model_dump(by_alias=True, exclude_none=True) if tcps and tcps.request else None,
             response=tcps.response.model_dump(by_alias=True, exclude_none=True) if tcps and tcps.response else None,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=str(host.random_user_agent) if host.random_user_agent is not None else "",
         )
     else:
         # Unknown network type, default to TCP
@@ -339,7 +339,7 @@ async def _prepare_subscription_inbound_data(
             host=host_list,
             header_type=inbound_header_type,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=str(host.random_user_agent) if host.random_user_agent is not None else "",
         )
 
     return SubscriptionInboundData(

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -82,7 +82,7 @@ class GRPCTransportConfig(BaseTransportConfig):
     permit_without_stream: bool = Field(False)
     initial_windows_size: int | None = Field(None)
     http_headers: dict[str, str] | None = Field(None)
-    random_user_agent: bool = Field(False)
+    random_user_agent: str = Field("")
 
 
 class WebSocketTransportConfig(BaseTransportConfig):
@@ -90,7 +90,7 @@ class WebSocketTransportConfig(BaseTransportConfig):
 
     heartbeat_period: int | None = Field(None, serialization_alias="heartbeatPeriod")
     http_headers: dict[str, str] | None = Field(None)
-    random_user_agent: bool = Field(False)
+    random_user_agent: str = Field("")
 
 
 class XHTTPTransportConfig(BaseTransportConfig):
@@ -123,7 +123,7 @@ class XHTTPTransportConfig(BaseTransportConfig):
     xmux: dict[str, Any] | None = Field(None)
     download_settings: SubscriptionInboundData | dict | None = Field(None, serialization_alias="downloadSettings")
     http_headers: dict[str, str] | None = Field(None)
-    random_user_agent: bool = Field(False)
+    random_user_agent: str = Field("")
 
 
 class KCPTransportConfig(BaseTransportConfig):
@@ -151,7 +151,7 @@ class TCPTransportConfig(BaseTransportConfig):
     request: dict[str, Any] | None = Field(None)
     response: dict[str, Any] | None = Field(None)
     http_headers: dict[str, str] | None = Field(None)
-    random_user_agent: bool = Field(False)
+    random_user_agent: str = Field("")
 
 
 # ========== Protocol-Specific Models (Only protocol fields) ==========
@@ -258,7 +258,7 @@ class SubscriptionInboundData(BaseModel):
     inbound_flow: str = Field("")
 
     # Additional settings
-    random_user_agent: bool = Field(False)
+    random_user_agent: str = Field("")
     use_sni_as_host: bool = Field(False)
     # Fragment and noise settings
     fragment_settings: dict[str, Any] | None = Field(None)


### PR DESCRIPTION
## Description

Fix #504 — Panel crashes on startup because `random_user_agent` field type was `bool` but Pydantic 2.13 strictly enforces validation and throws `TypeError` when trying to apply a string `pattern` constraint to a boolean/int value.

## Changes

### app/models/subscription.py
Changed `random_user_agent` field type from `bool = Field(False)` to `str = Field("")` across 5 model classes:
- `GRPCTransportConfig`
- `WebSocketTransportConfig`
- `XHTTPTransportConfig`
- `TCPTransportConfig`
- `SubscriptionInboundData`

### app/core/hosts.py
Added safe string conversion when reading `random_user_agent` from database host records across all 5 transport initialization blocks (xhttp, grpc, ws/websocket, tcp/raw/http/h2, unknown default):
```python
random_user_agent=str(host.random_user_agent) if host.random_user_agent is not None else ""
```

## Verification
- ✅ Ruff format: already formatted
- ✅ Ruff lint: all checks passed
- Tests skipped: project requires Python >=3.14 (system has 3.11)

## Fix details
| file | changes | +/- |
|------|---------|:---:|
| app/models/subscription.py | 5 type annotations changed | 0 + 0 - |
| app/core/hosts.py | 5 safe-conversion expressions added | 0 + 0 - |

---
🤖 Automatically generated by bounty-worker-v2
Closes #504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User agent handling in transport configurations has been updated to support string values instead of boolean values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PasarGuard/panel/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->