### PR TITLE
fix: safely convert random_user_agent to bool for Pydantic 2.13

### DIFF
--- a/app/core/hosts.py
+++ b/app/core/hosts.py
@@ -254,7 +254,7 @@ async def _prepare_subscription_inbound_data(
             xmux=xs.xmux.model_dump(by_alias=True, exclude_none=True) if xs and xs.xmux else None,
             download_settings=down_settings if xs and down_settings else None,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=bool(host.random_user_agent) if host.random_user_agent is not None else False,
         )
     elif network in ("grpc", "gun"):
         gs = ts.grpc_settings if ts else None
@@ -267,7 +267,7 @@ async def _prepare_subscription_inbound_data(
             permit_without_stream=gs.permit_without_stream if gs else False,
             initial_windows_size=gs.initial_windows_size if gs else None,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=bool(host.random_user_agent) if host.random_user_agent is not None else False,
         )
     elif network == "kcp":
         ks = ts.kcp_settings if ts else None
@@ -311,7 +311,7 @@ async def _prepare_subscription_inbound_data(
             host=host_list,
             heartbeat_period=ws.heartbeatPeriod if ws else None,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=bool(host.random_user_agent) if host.random_user_agent is not None else False,
         )
     elif network in ("tcp", "raw", "http", "h2"):
         # TCP/HTTP/H2 all use TCP transport
@@ -330,7 +330,7 @@ async def _prepare_subscription_inbound_data(
             request=tcps.request.model_dump(by_alias=True, exclude_none=True) if tcps and tcps.request else None,
             response=tcps.response.model_dump(by_alias=True, exclude_none=True) if tcps and tcps.response else None,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=bool(host.random_user_agent) if host.random_user_agent is not None else False,
         )
     else:
         # Unknown network type, default to TCP
@@ -339,7 +339,7 @@ async def _prepare_subscription_inbound_data(
             host=host_list,
             header_type=inbound_header_type,
             http_headers=host.http_headers,
-            random_user_agent=host.random_user_agent,
+            random_user_agent=bool(host.random_user_agent) if host.random_user_agent is not None else False,
         )
 
     return SubscriptionInboundData(
@@ -358,7 +358,7 @@ async def _prepare_subscription_inbound_data(
         encryption=encryption,
         vless_route=host.vless_route,
         inbound_flow=inbound_flow,
-        random_user_agent=host.random_user_agent,
+        random_user_agent=bool(host.random_user_agent) if host.random_user_agent is not None else False,
         use_sni_as_host=host.use_sni_as_host,
         fragment_settings=host.fragment_settings.model_dump() if host.fragment_settings else None,
         noise_settings=host.noise_settings.model_dump() if host.noise_settings else None,

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -125,6 +125,18 @@ class XHTTPTransportConfig(BaseTransportConfig):
     http_headers: dict[str, str] | None = Field(None)
     random_user_agent: bool = Field(False)
 
+    @field_validator(
+        "sc_max_each_post_bytes",
+        "sc_min_posts_interval_ms",
+        "uplink_chunk_size",
+        mode="before",
+    )
+    @classmethod
+    def normalize_numeric_or_range_fields(cls, value):
+        if isinstance(value, int):
+            return str(value)
+        return value
+
 
 class KCPTransportConfig(BaseTransportConfig):
     """KCP transport - only kcp-specific fields"""


### PR DESCRIPTION
Fixes #504

**Problem:** Pydantic 2.13 strict mode converts `False` to `0` (int), and when a `pattern` constraint is applied to a non-string field, it throws `TypeError`.

**Previous approach (#505):** Changed `random_user_agent` from `bool` to `str`.

**This fix:** Keeps `random_user_agent: bool` as the maintainer intended. Instead, safely converts the database value to `bool` before passing it to the Pydantic model constructor using `bool(value) if value is not None else False`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize user-agent randomization flag across subscription transports to a strict boolean, improving consistency.
  * Normalize numeric-or-range transport fields when integers are provided (converted for consistent validation/serialization), reducing validation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PasarGuard/panel/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->