### PR TITLE
fix(subscription): strip spaces from finalmask fm= param so clients can parse it

### DIFF
--- a/app/core/hosts.py
+++ b/app/core/hosts.py
@@ -186,6 +186,7 @@ async def _prepare_subscription_inbound_data(
         inbound_flow = ""
 
     finalmask = inbound_config.get("finalmask")
+    finalmask_link = json.dumps(finalmask, separators=(",", ":")) if finalmask else None
 
     # Network comes from inbound, NOT from checking which transport exists on host!
     # Host can have ALL transport configs, inbound determines which one is used
@@ -386,6 +387,7 @@ async def _prepare_subscription_inbound_data(
         fragment_settings=host.fragment_settings.model_dump() if host.fragment_settings else None,
         noise_settings=host.noise_settings.model_dump() if host.noise_settings else None,
         finalmask=finalmask,
+        finalmask_link=finalmask_link,
         priority=host.priority,
         status=list(host.status) if host.status else None,
         subscription_templates=host.subscription_templates.model_dump(exclude_none=True)

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -279,6 +279,7 @@ class SubscriptionInboundData(BaseModel):
     fragment_settings: dict[str, Any] | None = Field(None)
     noise_settings: dict[str, Any] | None = Field(None)
     finalmask: dict[str, Any] | None = Field(None)
+    finalmask_link: str | None = Field(None)
 
     # Priority and status
     priority: int = Field(0)

--- a/app/subscription/links.py
+++ b/app/subscription/links.py
@@ -167,7 +167,7 @@ class StandardLinks(BaseSubscription):
     def _apply_finalmask(self, payload: dict, protocol: str, inbound: SubscriptionInboundData):
         """Apply finalMask for vmess if needed"""
         if inbound.finalmask:
-            payload["fm"] = json.dumps(inbound.finalmask)
+            payload["fm"] = inbound.finalmask_link
 
     def _transport_tcp(self, payload: dict, protocol: str, config: TCPTransportConfig, path: str):
         """Handle tcp/raw/http transport - only gets TCP config"""


### PR DESCRIPTION
**Problem.** `app/subscription/links.py` builds the finalmask `fm=` link param via `json.dumps(inbound.finalmask)`, which uses the default separators with spaces. The link is then assembled with `urllib.parse.urlencode(payload)` (e.g. line 282 for VLESS), and `urlencode` defaults to `quote_plus`, which encodes those spaces as `+`.

Clients that parse the link query per RFC 3986 (v2rayNG, v2rayN) treat `+` as a literal plus, not a space, so they never turn it back. The `fm` value then arrives as broken JSON, e.g. `{"udp":+[{"type":+"xdns",+...` — the client chokes on it and the entry fails to apply. This affects any finalmask type with no native link param (XDNS, the `header-*` masks); Hysteria2 `salamander` dodges it because it's also emitted via the native `obfs`/`obfs-password` params. Confirmed on both a VLESS + finalmask `xdns` link and a Hysteria2 + `salamander` link.

**Fix.** Serialize the finalmask once, with compact JSON (`separators=(",", ":")`, so there are no spaces to encode), when the host's `SubscriptionInboundData` is prepared in `_prepare_subscription_inbound_data`. Store it as `finalmask_link` and read that in the link builders. Since prepared hosts are cached in `HostManager._hosts` / NATS KV, it's formatted once per host instead of on every request — and it mirrors how the XHTTP `extra` param already avoids the same encoding issue (line 138).

**Tested.** PasarGuard v5.0.0 + xray-core 26.6.1. Before: the generated link contains `fm=%7B%22udp%22%3A+%5B...` (the `+` where the spaces were), and v2rayNG / v2rayN fail to apply finalmask. After: `fm` is compact JSON, and both clients parse and apply it end-to-end (verified with XDNS and Hysteria2/salamander).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized finalmask data handling in subscription links. Finalmask values are now pre-serialized during subscription preparation and directly applied to link payloads, replacing inline serialization for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->