### PR TITLE
fix(subscription): encode spaces as %20 not + in share links

### DIFF
--- a/app/subscription/base.py
+++ b/app/subscription/base.py
@@ -228,6 +228,6 @@ class BaseSubscription:
             "payload": payload,
             "uri": (
                 f"wireguard://{quote(private_key, safe='')}@{address}:{inbound.port}/"
-                f"?{urlencode(uri_payload)}#{quote(validated_remark)}"
+                f"?{urlencode(uri_payload, quote_via=quote)}#{quote(validated_remark)}"
             ),
         }

--- a/app/subscription/links.py
+++ b/app/subscription/links.py
@@ -280,7 +280,7 @@ class StandardLinks(BaseSubscription):
             self._apply_tls_settings(payload, inbound.tls_config, inbound.fragment_settings)
 
         payload = self._normalize_and_remove_none_values(payload)
-        return f"vless://{id}@{address}:{inbound.port}?{urlparse.urlencode(payload)}#{urlparse.quote(remark)}"
+        return f"vless://{id}@{address}:{inbound.port}?{urlparse.urlencode(payload, quote_via=urlparse.quote)}#{urlparse.quote(remark)}"
 
     def _build_trojan(self, remark: str, address: str, inbound: SubscriptionInboundData, settings: dict) -> str:
         """Build Trojan link"""
@@ -302,7 +302,7 @@ class StandardLinks(BaseSubscription):
 
         payload = self._normalize_and_remove_none_values(payload)
         password = urlparse.quote(settings["password"], safe=":")
-        return f"trojan://{password}@{address}:{inbound.port}?{urlparse.urlencode(payload)}#{urlparse.quote(remark)}"
+        return f"trojan://{password}@{address}:{inbound.port}?{urlparse.urlencode(payload, quote_via=urlparse.quote)}#{urlparse.quote(remark)}"
 
     def _build_shadowsocks(self, remark: str, address: str, inbound: SubscriptionInboundData, settings: dict) -> str:
         """Build Shadowsocks link"""
@@ -332,7 +332,7 @@ class StandardLinks(BaseSubscription):
             self._apply_tls_settings(payload, inbound.tls_config, inbound.fragment_settings)
 
         payload = self._normalize_and_remove_none_values(payload)
-        return f"hysteria2://{settings['auth']}@{address}:{inbound.port}?{urlparse.urlencode(payload)}#{urlparse.quote(remark)}"
+        return f"hysteria2://{settings['auth']}@{address}:{inbound.port}?{urlparse.urlencode(payload, quote_via=urlparse.quote)}#{urlparse.quote(remark)}"
 
     def _build_wireguard(self, remark: str, address: str, inbound: SubscriptionInboundData, settings: dict) -> str:
         """Build WireGuard link"""


### PR DESCRIPTION
## Problem

Header values containing spaces — e.g. a realistic `Accept-Encoding: gzip, deflate, br, zstd` inside the xHTTP `extra` payload — reach the client with literal `+` instead of spaces:

`gzip,+deflate,+br,+zstd`

The client's transport then sends that malformed value on the wire, breaking browser-mimicry and leaving an easy DPI fingerprint. The corruption is visible right after importing a generated subscription link.

## Root cause

`urllib.parse.urlencode(payload)` defaults to `quote_via=quote_plus`, which encodes spaces as `+` — the `application/x-www-form-urlencoded` convention. That's valid for form bodies but **not** for a generic URI query component.

Per [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986), `+` in a query is a **literal plus**, not a space; only `%20` denotes a space. Standards-compliant clients decode accordingly. For example, v2rayNG decodes strictly:

    // Utils.decodeURIComponent
    URLDecoder.decode(url.replace("+", "%2B"), Charsets.UTF_8.toString())

It deliberately rewrites `+` → `%2B` before decoding to preserve `+` as a literal (with an explicit comment rejecting `+`-as-space). So the panel's form-encoded space is read back as a literal `+`. The bug is on the producer side: we emit a form-encoded space into a URI query.

## Fix

Pass `quote_via=quote` to every `urlencode` call that builds a share-link query: the `vless`, `trojan` and `hysteria2` builders in `links.py`, plus the `wireguard` builder in `base.py`. `quote` encodes spaces as `%20`, which every RFC 3986 decoder maps back to a space.

`urlencode` forwards its own `safe` argument (default `""`) to `quote_via`, so reserved characters including `/` stay percent-encoded exactly as before (`/` → `%2F`, identical to the previous `quote_plus` output). The **only** behavioral change is the space: `+` → `%20`. No other field differs.

## Scope

| Builder | Status | Reason |
|---|---|---|
| `vless` (`links.py`) | fixed | carries transport query |
| `trojan` (`links.py`) | fixed | carries transport query |
| `hysteria2` (`links.py`) | fixed | carries transport query |
| `wireguard` (`base.py`) | fixed | same `urlencode` default; latent today (WG fields rarely contain spaces) but corrected for consistency |
| `vmess` | unaffected | base64-encoded JSON; values preserved verbatim |
| `shadowsocks` | unaffected | no `urlencode` query; credentials are base64 userinfo, only `remark` encoded (already via `quote`) |
| Clash / sing-box / Xray-JSON / Outline | unaffected | emit config bodies, not URI-query links — no percent-encoding involved |

## Relation to #583

#583 fixed the same root cause for the `fm=` (finalmask) param only, and did so by removing the spaces at the source (compact `json.dumps(separators=(",", ":"))` cached as `finalmask_link`). That approach works for finalmask because its JSON has no semantically required spaces.

This PR fixes the encoder itself, covering every other field where spaces are meaningful and cannot simply be stripped — most importantly HTTP header values inside the xHTTP `extra` payload (`Accept-Encoding: gzip, deflate, br, zstd`). The two are complementary, not duplicates.

## Verification

Round-trip through a v2rayNG-equivalent decoder (`unquote(value.replace("+", "%2B"))`):

| | link payload | decoded by client |
|---|---|---|
| **before** | `gzip%2C+deflate%2C+br%2C+zstd` | `gzip,+deflate,+br,+zstd` (broken) |
| **after** | `gzip%2C%20deflate%2C%20br%2C%20zstd` | `gzip, deflate, br, zstd` (correct) |

Paths confirmed identical before/after (`/assets/e` → `%2Fassets%2Fe` in both). Values without spaces are byte-for-byte unchanged.

