### PR TITLE
fix: XMuxSettings camelCase deserialization (xMux lost in VLESS links)

### DIFF
--- a/app/models/host.py
+++ b/app/models/host.py
@@ -63,16 +63,16 @@ class NoiseSettings(BaseModel):
 
 
 class XMuxSettings(BaseModel):
-    max_concurrency: str | None = Field(None, pattern=r"^\d{1,16}(-\d{1,16})?$", serialization_alias="maxConcurrency")
-    max_connections: str | None = Field(None, pattern=r"^\d{1,16}(-\d{1,16})?$", serialization_alias="maxConnections")
-    c_max_reuse_times: str | None = Field(None, pattern=r"^\d{1,16}(-\d{1,16})?$", serialization_alias="cMaxReuseTimes")
+    max_concurrency: str | None = Field(None, pattern=r"^\d{1,16}(-\d{1,16})?$", alias="maxConcurrency")
+    max_connections: str | None = Field(None, pattern=r"^\d{1,16}(-\d{1,16})?$", alias="maxConnections")
+    c_max_reuse_times: str | None = Field(None, pattern=r"^\d{1,16}(-\d{1,16})?$", alias="cMaxReuseTimes")
     h_max_reusable_secs: str | None = Field(
-        None, pattern=r"^\d{1,16}(-\d{1,16})?$", serialization_alias="hMaxReusableSecs"
+        None, pattern=r"^\d{1,16}(-\d{1,16})?$", alias="hMaxReusableSecs"
     )
     h_max_request_times: str | None = Field(
-        None, pattern=r"^\d{1,16}(-\d{1,16})?$", serialization_alias="hMaxRequestTimes"
+        None, pattern=r"^\d{1,16}(-\d{1,16})?$", alias="hMaxRequestTimes"
     )
-    h_keep_alive_period: int | None = Field(None, serialization_alias="hKeepAlivePeriod")
+    h_keep_alive_period: int | None = Field(None, alias="hKeepAlivePeriod")
 
     @field_validator(
         "max_concurrency",


### PR DESCRIPTION
## Description

XMux settings in hosts.transport_settings silently lost. extra parameter in VLESS links never contains xmux.

## Root Cause

serialization_alias in Pydantic v2 only affects output, not input. JSON camelCase keys not mapped to snake_case fields.

## Fix

Replace serialization_alias with alias in XMuxSettings (6 fields).

## Verification

Before: XMuxSettings(**{maxConcurrency: 8}).max_concurrency -> None
After: XMuxSettings(**{maxConcurrency: 8}).max_concurrency -> 8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how connection and reuse configuration settings are serialized and deserialized. This ensures consistent handling of these parameters in configuration exchanges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->