### PR TITLE
perf: eliminate copy.deepcopy from core state management and notifications

### DIFF
--- a/app/core/hosts.py
+++ b/app/core/hosts.py
@@ -418,7 +418,7 @@ class HostManager:
 
     async def _snapshot_state(self) -> dict[int, dict]:
         async with self._lock:
-            return deepcopy(self._hosts)
+            return dict(self._hosts)
 
     async def _persist_state(self):
         if not self._kv:

--- a/app/core/manager.py
+++ b/app/core/manager.py
@@ -52,22 +52,17 @@ class CoreManager:
     async def _snapshot_state(self) -> dict:
         async with self._lock:
             return {
-                "cores": deepcopy(self._cores),
-                "inbounds": deepcopy(self._inbounds),
-                "inbounds_by_tag": deepcopy(self._inbounds_by_tag),
+                "cores": {k: v.to_json() for k, v in self._cores.items()},
+                "inbounds": list(self._inbounds),
+                "inbounds_by_tag": dict(self._inbounds_by_tag),
             }
 
     async def _persist_state(self):
         if not self._kv:
             return
         state = await self._snapshot_state()
-
-        # Manually serialize cores to their JSON representation
-        serialized_state = deepcopy(state)
-        serialized_state["cores"] = {str(k): v.to_json() for k, v in state.get("cores", {}).items()}
-
-        # Serialize state using JSON
-        state_bytes = json.dumps(serialized_state).encode("utf-8")
+        # State is already serialized by _snapshot_state; just encode
+        state_bytes = json.dumps(state).encode("utf-8")
         try:
             await self._kv.put(self.STATE_CACHE_KEY, state_bytes)
         except Exception as exc:
@@ -298,14 +293,13 @@ class CoreManager:
     async def get_cores(self, core_ids: list[int] | set[int] | None = None) -> dict[int, AbstractCore]:
         async with self._lock:
             if core_ids is None:
-                return deepcopy(self._cores)
-
+                return {core_id: deepcopy(core) for core_id, core in self._cores.items()}
             return {core_id: deepcopy(core) for core_id, core in self._cores.items() if core_id in core_ids}
 
     @cached()
     async def get_inbounds(self) -> list[str]:
         async with self._lock:
-            return deepcopy(self._inbounds)
+            return list(self._inbounds)
 
     @cached()
     async def get_inbounds_by_tag(self) -> dict:

--- a/app/notification/discord/admin.py
+++ b/app/notification/discord/admin.py
@@ -1,5 +1,3 @@
-import copy
-
 from app.models.admin import AdminDetails
 from app.models.settings import NotificationSettings
 from app.notification.client import send_discord_webhook
@@ -15,7 +13,7 @@ ENTITY = "admin"
 
 async def create_admin(admin: AdminDetails, by: str):
     username, by = escape_ds_markdown_list((admin.username, by))
-    message = copy.deepcopy(messages.CREATE_ADMIN)
+    message = {**messages.CREATE_ADMIN, "footer": dict(messages.CREATE_ADMIN["footer"])}
     role = admin.role.name if admin.role else "unknown"
     message["description"] = message["description"].format(
         username=username,
@@ -37,7 +35,7 @@ async def create_admin(admin: AdminDetails, by: str):
 
 async def modify_admin(admin: AdminDetails, by: str):
     username, by = escape_ds_markdown_list((admin.username, by))
-    message = copy.deepcopy(messages.MODIFY_ADMIN)
+    message = {**messages.MODIFY_ADMIN, "footer": dict(messages.MODIFY_ADMIN["footer"])}
     role = admin.role.name if admin.role else "unknown"
     message["description"] = message["description"].format(
         username=username,
@@ -59,7 +57,7 @@ async def modify_admin(admin: AdminDetails, by: str):
 
 async def remove_admin(username: str, by: str):
     username, by = escape_ds_markdown_list((username, by))
-    message = copy.deepcopy(messages.REMOVE_ADMIN)
+    message = {**messages.REMOVE_ADMIN, "footer": dict(messages.REMOVE_ADMIN["footer"])}
     message["description"] = message["description"].format(username=username)
     message["footer"]["text"] = message["footer"]["text"].format(by=by)
     data = {
@@ -75,7 +73,7 @@ async def remove_admin(username: str, by: str):
 
 async def admin_reset_usage(admin: AdminDetails, by: str):
     username, by = escape_ds_markdown_list((admin.username, by))
-    message = copy.deepcopy(messages.ADMIN_RESET_USAGE)
+    message = {**messages.ADMIN_RESET_USAGE, "footer": dict(messages.ADMIN_RESET_USAGE["footer"])}
     message["description"] = message["description"].format(username=username)
     message["footer"]["text"] = message["footer"]["text"].format(by=by)
     data = {
@@ -91,7 +89,7 @@ async def admin_reset_usage(admin: AdminDetails, by: str):
 
 async def admin_usage_limit_reached(admin: AdminDetails, usage_percentage: int, threshold: int):
     username = escape_ds_markdown_list((admin.username,))[0]
-    message = copy.deepcopy(messages.ADMIN_USAGE_LIMIT_REACHED)
+    message = {**messages.ADMIN_USAGE_LIMIT_REACHED}
     message["description"] = message["description"].format(
         username=username,
         used_traffic=readable_size(admin.used_traffic),
@@ -111,7 +109,7 @@ async def admin_usage_limit_reached(admin: AdminDetails, usage_percentage: int, 
 
 async def admin_login(username: str, password: str, client_ip: str, success: bool):
     username, password = escape_ds_markdown_list((username, password))
-    message = copy.deepcopy(messages.ADMIN_LOGIN)
+    message = {**messages.ADMIN_LOGIN, "footer": dict(messages.ADMIN_LOGIN["footer"])}
     message["description"] = message["description"].format(
         username=username,
         password="🔒" if success else password,

--- a/app/notification/discord/admin_role.py
+++ b/app/notification/discord/admin_role.py
@@ -1,5 +1,3 @@
-import copy
-
 from app.notification.client import send_discord_webhook
 from app.notification.helpers import get_discord_webhook
 from app.models.admin_role import AdminRoleResponse
@@ -14,7 +12,7 @@ ENTITY = "admin_role"
 
 async def create_admin_role(role: AdminRoleResponse, by: str):
     name, by = escape_ds_markdown_list((role.name, by))
-    message = copy.deepcopy(messages.CREATE_ADMIN_ROLE)
+    message = {**messages.CREATE_ADMIN_ROLE, "footer": dict(messages.CREATE_ADMIN_ROLE["footer"])}
     message["description"] = message["description"].format(name=name, is_owner=role.is_owner)
     message["footer"]["text"] = message["footer"]["text"].format(id=role.id, by=by)
     data = {"content": "", "embeds": [message]}
@@ -27,7 +25,7 @@ async def create_admin_role(role: AdminRoleResponse, by: str):
 
 async def modify_admin_role(role: AdminRoleResponse, by: str):
     name, by = escape_ds_markdown_list((role.name, by))
-    message = copy.deepcopy(messages.MODIFY_ADMIN_ROLE)
+    message = {**messages.MODIFY_ADMIN_ROLE, "footer": dict(messages.MODIFY_ADMIN_ROLE["footer"])}
     message["description"] = message["description"].format(name=name, is_owner=role.is_owner)
     message["footer"]["text"] = message["footer"]["text"].format(id=role.id, by=by)
     data = {"content": "", "embeds": [message]}
@@ -40,7 +38,7 @@ async def modify_admin_role(role: AdminRoleResponse, by: str):
 
 async def remove_admin_role(role: AdminRoleResponse, by: str):
     name, by = escape_ds_markdown_list((role.name, by))
-    message = copy.deepcopy(messages.REMOVE_ADMIN_ROLE)
+    message = {**messages.REMOVE_ADMIN_ROLE, "footer": dict(messages.REMOVE_ADMIN_ROLE["footer"])}
     message["description"] = message["description"].format(name=name)
     message["footer"]["text"] = message["footer"]["text"].format(id=role.id, by=by)
     data = {"content": "", "embeds": [message]}

--- a/app/notification/discord/core.py
+++ b/app/notification/discord/core.py
@@ -1,5 +1,3 @@
-import copy
-
 from app.notification.client import send_discord_webhook
 from app.notification.helpers import get_discord_webhook
 from app.models.core import CoreResponse
@@ -15,7 +13,7 @@ ENTITY = "core"
 
 async def create_core(core: CoreResponse, by: str):
     name, exclude_inbound_tags, fallbacks_inbound_tags, by = escape_md_core(core, by)
-    message = copy.deepcopy(messages.CREATE_CORE)
+    message = {**messages.CREATE_CORE, "footer": dict(messages.CREATE_CORE["footer"])}
     message["description"] = message["description"].format(
         name=name,
         exclude_inbound_tags=exclude_inbound_tags,
@@ -35,7 +33,7 @@ async def create_core(core: CoreResponse, by: str):
 
 async def modify_core(core: CoreResponse, by: str):
     name, exclude_inbound_tags, fallbacks_inbound_tags, by = escape_md_core(core, by)
-    message = copy.deepcopy(messages.MODIFY_CORE)
+    message = {**messages.MODIFY_CORE, "footer": dict(messages.MODIFY_CORE["footer"])}
     message["description"] = message["description"].format(
         name=name,
         exclude_inbound_tags=exclude_inbound_tags,
@@ -55,7 +53,7 @@ async def modify_core(core: CoreResponse, by: str):
 
 async def remove_core(core_id: int, by: str):
     by = escape_ds_markdown(by)
-    message = copy.deepcopy(messages.REMOVE_CORE)
+    message = {**messages.REMOVE_CORE, "footer": dict(messages.REMOVE_CORE["footer"])}
     message["description"] = message["description"].format(id=core_id)
     message["footer"]["text"] = message["footer"]["text"].format(by=by)
     data = {

--- a/app/notification/discord/group.py
+++ b/app/notification/discord/group.py
@@ -1,5 +1,3 @@
-import copy
-
 from app.notification.client import send_discord_webhook
 from app.notification.helpers import get_discord_webhook
 from app.models.group import GroupResponse
@@ -14,7 +12,7 @@ ENTITY = "group"
 
 async def create_group(group: GroupResponse, by: str):
     name, by = escape_ds_markdown_list((group.name, by))
-    message = copy.deepcopy(messages.CREATE_GROUP)
+    message = {**messages.CREATE_GROUP, "footer": dict(messages.CREATE_GROUP["footer"])}
     message["description"] = message["description"].format(
         name=name,
         inbound_tags=group.inbound_tags,
@@ -34,7 +32,7 @@ async def create_group(group: GroupResponse, by: str):
 
 async def modify_group(group: GroupResponse, by: str):
     name, by = escape_ds_markdown_list((group.name, by))
-    message = copy.deepcopy(messages.MODIFY_GROUP)
+    message = {**messages.MODIFY_GROUP, "footer": dict(messages.MODIFY_GROUP["footer"])}
     message["description"] = message["description"].format(
         name=name,
         inbound_tags=group.inbound_tags,
@@ -54,7 +52,7 @@ async def modify_group(group: GroupResponse, by: str):
 
 async def remove_group(group_id: int, by: str):
     by = escape_ds_markdown(by)
-    message = copy.deepcopy(messages.REMOVE_GROUP)
+    message = {**messages.REMOVE_GROUP, "footer": dict(messages.REMOVE_GROUP["footer"])}
     message["description"] = message["description"].format(id=group_id)
     message["footer"]["text"] = message["footer"]["text"].format(by=by)
     data = {

--- a/app/notification/discord/host.py
+++ b/app/notification/discord/host.py
@@ -1,5 +1,3 @@
-import copy
-
 from app.notification.client import send_discord_webhook
 from app.notification.helpers import get_discord_webhook
 from app.models.host import BaseHost
@@ -15,7 +13,7 @@ ENTITY = "host"
 
 async def create_host(host: BaseHost, by: str):
     remark, address, inbound_tag, by = escape_md_host(host, by)
-    message = copy.deepcopy(messages.CREATE_HOST)
+    message = {**messages.CREATE_HOST, "footer": dict(messages.CREATE_HOST["footer"])}
     message["description"] = message["description"].format(
         remark=remark, address=address, inbound_tag=inbound_tag, port=host.port
     )
@@ -33,7 +31,7 @@ async def create_host(host: BaseHost, by: str):
 
 async def modify_host(host: BaseHost, by: str):
     remark, address, inbound_tag, by = escape_md_host(host, by)
-    message = copy.deepcopy(messages.MODIFY_HOST)
+    message = {**messages.MODIFY_HOST, "footer": dict(messages.MODIFY_HOST["footer"])}
     message["description"] = message["description"].format(
         remark=remark, address=address, inbound_tag=inbound_tag, port=host.port
     )
@@ -51,7 +49,7 @@ async def modify_host(host: BaseHost, by: str):
 
 async def remove_host(host: BaseHost, by: str):
     remark, by = escape_ds_markdown_list((host.remark, by))
-    message = copy.deepcopy(messages.REMOVE_HOST)
+    message = {**messages.REMOVE_HOST, "footer": dict(messages.REMOVE_HOST["footer"])}
     message["description"] = message["description"].format(remark=remark)
     message["footer"]["text"] = message["footer"]["text"].format(id=host.id, by=by)
     data = {
@@ -67,7 +65,7 @@ async def remove_host(host: BaseHost, by: str):
 
 async def modify_hosts(by: str):
     by = escape_ds_markdown(by)
-    message = copy.deepcopy(messages.MODIFY_HOSTS)
+    message = {**messages.MODIFY_HOSTS}
     message["description"] = message["description"].format(by=by)
     data = {
         "content": "",

--- a/app/notification/discord/node.py
+++ b/app/notification/discord/node.py
@@ -1,5 +1,3 @@
-import copy
-
 from app.notification.client import send_discord_webhook
 from app.notification.helpers import get_discord_webhook
 from app.models.node import NodeNotification, NodeResponse
@@ -15,7 +13,7 @@ ENTITY = "node"
 
 async def create_node(node: NodeResponse, by: str):
     name, by = escape_ds_markdown_list((node.name, by))
-    message = copy.deepcopy(messages.CREATE_NODE)
+    message = {**messages.CREATE_NODE, "footer": dict(messages.CREATE_NODE["footer"])}
     message["description"] = message["description"].format(name=name, address=node.address, port=node.port)
     message["footer"]["text"] = message["footer"]["text"].format(id=node.id, by=by)
     data = {
@@ -31,7 +29,7 @@ async def create_node(node: NodeResponse, by: str):
 
 async def modify_node(node: NodeResponse, by: str):
     name, by = escape_ds_markdown_list((node.name, by))
-    message = copy.deepcopy(messages.MODIFY_NODE)
+    message = {**messages.MODIFY_NODE, "footer": dict(messages.MODIFY_NODE["footer"])}
     message["description"] = message["description"].format(name=name, address=node.address, port=node.port)
     message["footer"]["text"] = message["footer"]["text"].format(id=node.id, by=by)
     data = {
@@ -47,7 +45,7 @@ async def modify_node(node: NodeResponse, by: str):
 
 async def remove_node(node: NodeResponse, by: str):
     name, by = escape_ds_markdown_list((node.name, by))
-    message = copy.deepcopy(messages.REMOVE_NODE)
+    message = {**messages.REMOVE_NODE, "footer": dict(messages.REMOVE_NODE["footer"])}
     message["description"] = message["description"].format(name=name, address=node.address, port=node.port)
     message["footer"]["text"] = message["footer"]["text"].format(id=node.id, by=by)
     data = {
@@ -63,7 +61,7 @@ async def remove_node(node: NodeResponse, by: str):
 
 async def connect_node(node: NodeNotification):
     name = escape_ds_markdown(node.name)
-    message = copy.deepcopy(messages.CONNECT_NODE)
+    message = {**messages.CONNECT_NODE, "footer": dict(messages.CONNECT_NODE["footer"])}
     message["description"] = message["description"].format(
         name=name, node_version=node.node_version, core_version=node.core_version
     )
@@ -81,7 +79,7 @@ async def connect_node(node: NodeNotification):
 
 async def error_node(node: NodeNotification):
     name, node_message = escape_ds_markdown_list((node.name, node.message))
-    message = copy.deepcopy(messages.ERROR_NODE)
+    message = {**messages.ERROR_NODE, "footer": dict(messages.ERROR_NODE["footer"])}
     message["description"] = message["description"].format(name=name, error=node_message)
     message["footer"]["text"] = message["footer"]["text"].format(id=node.id)
     data = {
@@ -97,7 +95,7 @@ async def error_node(node: NodeNotification):
 
 async def limited_node(node: NodeNotification, data_limit: int, used_traffic: int):
     name = escape_ds_markdown(node.name)
-    message = copy.deepcopy(messages.LIMITED_NODE)
+    message = {**messages.LIMITED_NODE, "footer": dict(messages.LIMITED_NODE["footer"])}
     message["description"] = message["description"].format(
         name=name, data_limit=readable_size(data_limit), used_traffic=readable_size(used_traffic)
     )
@@ -115,7 +113,7 @@ async def limited_node(node: NodeNotification, data_limit: int, used_traffic: in
 
 async def reset_node_usage(node: NodeResponse, by: str, uplink: int, downlink: int):
     name, by_escaped = escape_ds_markdown_list((node.name, by))
-    message = copy.deepcopy(messages.RESET_NODE_USAGE)
+    message = {**messages.RESET_NODE_USAGE, "footer": dict(messages.RESET_NODE_USAGE["footer"])}
     message["description"] = message["description"].format(
         name=name, uplink=readable_size(uplink), downlink=readable_size(downlink)
     )

--- a/app/notification/discord/user.py
+++ b/app/notification/discord/user.py
@@ -1,5 +1,3 @@
-import copy
-
 from app.models.settings import NotificationSettings
 from app.models.user import UserNotificationResponse
 from app.notification.client import send_discord_webhook
@@ -30,7 +28,7 @@ _status_color = {
 
 async def user_status_change(user: UserNotificationResponse, by: str):
     username, admin_username, by = escape_md_user(user, by)
-    message = copy.deepcopy(messages.USER_STATUS_CHANGE)
+    message = {**messages.USER_STATUS_CHANGE, "footer": dict(messages.USER_STATUS_CHANGE["footer"])}
     message["title"] = message["title"].format(status=_status[user.status.value])
     message["description"] = message["description"].format(username=username)
     message["footer"]["text"] = message["footer"]["text"].format(admin_username=admin_username, by=by)
@@ -50,7 +48,7 @@ async def user_status_change(user: UserNotificationResponse, by: str):
 
 async def create_user(user: UserNotificationResponse, by: str):
     username, admin_username, by = escape_md_user(user, by)
-    message = copy.deepcopy(messages.CREATE_USER)
+    message = {**messages.CREATE_USER, "footer": dict(messages.CREATE_USER["footer"])}
     message["description"] = message["description"].format(
         username=username,
         data_limit=readable_size(user.data_limit) if user.data_limit else "Unlimited",
@@ -76,7 +74,7 @@ async def create_user(user: UserNotificationResponse, by: str):
 
 async def modify_user(user: UserNotificationResponse, by: str):
     username, admin_username, by = escape_md_user(user, by)
-    message = copy.deepcopy(messages.MODIFY_USER)
+    message = {**messages.MODIFY_USER, "footer": dict(messages.MODIFY_USER["footer"])}
     message["description"] = message["description"].format(
         username=username,
         data_limit=readable_size(user.data_limit) if user.data_limit else "Unlimited",
@@ -102,7 +100,7 @@ async def modify_user(user: UserNotificationResponse, by: str):
 
 async def remove_user(user: UserNotificationResponse, by: str):
     username, admin_username, by = escape_md_user(user, by)
-    message = copy.deepcopy(messages.REMOVE_USER)
+    message = {**messages.REMOVE_USER, "footer": dict(messages.REMOVE_USER["footer"])}
     message["description"] = message["description"].format(username=username)
     message["footer"]["text"] = message["footer"]["text"].format(id=user.id, admin_username=admin_username, by=by)
     data = {
@@ -121,7 +119,7 @@ async def remove_user(user: UserNotificationResponse, by: str):
 
 async def reset_user_data_usage(user: UserNotificationResponse, by: str):
     username, admin_username, by = escape_md_user(user, by)
-    message = copy.deepcopy(messages.RESET_USER_DATA_USAGE)
+    message = {**messages.RESET_USER_DATA_USAGE, "footer": dict(messages.RESET_USER_DATA_USAGE["footer"])}
     message["description"] = message["description"].format(
         username=username,
         data_limit=readable_size(user.data_limit) if user.data_limit else "Unlimited",
@@ -143,7 +141,7 @@ async def reset_user_data_usage(user: UserNotificationResponse, by: str):
 
 async def user_data_reset_by_next(user: UserNotificationResponse, by: str):
     username, admin_username, by = escape_md_user(user, by)
-    message = copy.deepcopy(messages.USER_DATA_RESET_BY_NEXT)
+    message = {**messages.USER_DATA_RESET_BY_NEXT, "footer": dict(messages.USER_DATA_RESET_BY_NEXT["footer"])}
     message["description"] = message["description"].format(
         username=username,
         data_limit=readable_size(user.data_limit) if user.data_limit else "Unlimited",
@@ -166,7 +164,7 @@ async def user_data_reset_by_next(user: UserNotificationResponse, by: str):
 
 async def user_subscription_revoked(user: UserNotificationResponse, by: str):
     username, admin_username, by = escape_md_user(user, by)
-    message = copy.deepcopy(messages.USER_SUBSCRIPTION_REVOKED)
+    message = {**messages.USER_SUBSCRIPTION_REVOKED, "footer": dict(messages.USER_SUBSCRIPTION_REVOKED["footer"])}
     message["description"] = message["description"].format(username=username)
     message["footer"]["text"] = message["footer"]["text"].format(id=user.id, admin_username=admin_username, by=by)
     data = {

--- a/app/notification/discord/user_template.py
+++ b/app/notification/discord/user_template.py
@@ -1,5 +1,3 @@
-import copy
-
 from app.notification.client import send_discord_webhook
 from app.notification.helpers import get_discord_webhook
 from app.models.user_template import UserTemplateResponse
@@ -15,7 +13,7 @@ ENTITY = "user_template"
 
 async def create_user_template(user_tempelate: UserTemplateResponse, by: str):
     name, username_prefix, username_suffix, by = escape_md_template(user_tempelate, by)
-    message = copy.deepcopy(messages.CREATE_USER_TEMPLATE)
+    message = {**messages.CREATE_USER_TEMPLATE, "footer": dict(messages.CREATE_USER_TEMPLATE["footer"])}
     message["description"] = message["description"].format(
         name=name,
         data_limit=user_tempelate.data_limit,
@@ -37,7 +35,7 @@ async def create_user_template(user_tempelate: UserTemplateResponse, by: str):
 
 async def modify_user_template(user_template: UserTemplateResponse, by: str):
     name, username_prefix, username_suffix, by = escape_md_template(user_template, by)
-    message = copy.deepcopy(messages.MODIFY_USER_TEMPLATE)
+    message = {**messages.MODIFY_USER_TEMPLATE, "footer": dict(messages.MODIFY_USER_TEMPLATE["footer"])}
     message["description"] = message["description"].format(
         name=name,
         data_limit=user_template.data_limit,
@@ -59,7 +57,7 @@ async def modify_user_template(user_template: UserTemplateResponse, by: str):
 
 async def remove_user_template(name: str, by: str):
     name, by = escape_ds_markdown_list((name, by))
-    message = copy.deepcopy(messages.REMOVE_USER_TEMPLATE)
+    message = {**messages.REMOVE_USER_TEMPLATE, "footer": dict(messages.REMOVE_USER_TEMPLATE["footer"])}
     message["description"] = message["description"].format(name=name)
     message["footer"]["text"] = message["footer"]["text"].format(by=by)
     data = {

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -2,7 +2,6 @@ import base64
 import random
 import secrets
 from collections import defaultdict
-from copy import deepcopy
 from datetime import datetime as dt, timedelta, timezone
 
 from jdatetime import date as jd
@@ -270,8 +269,8 @@ async def process_host(
     if inbound.use_sni_as_host and sni:
         req_host = sni
 
-    # Create a copy of the inbound data with selected random values
-    inbound_copy = deepcopy(inbound)
+    # Create a shallow copy of the inbound data with selected random values
+    inbound_copy = inbound.model_copy()
 
     # Update TLS config with selected values
     inbound_copy.tls_config.sni = sni


### PR DESCRIPTION
## Changes

- **CoreManager** (`app/core/manager.py`): State snapshots use `dict()`/`list()` shallow copies. Getters return `deepcopy()` only for `AbstractCore` objects to prevent live state mutation
- **HostManager** (`app/core/hosts.py`): Uses `dict()` instead of `deepcopy()` for host state snapshots
- **Subscription** (`app/subscription/share.py`): Uses Pydantic `model_copy()` instead of `deepcopy()` for inbound data
- **Discord notifications** (8 files): Replaced 36 `copy.deepcopy()` calls with `{**template, "footer": dict(template["footer"])}` dict spread pattern

## Files Changed

- `app/core/manager.py`
- `app/core/hosts.py`
- `app/subscription/share.py`
- `app/notification/discord/admin.py`
- `app/notification/discord/admin_role.py`
- `app/notification/discord/core.py`
- `app/notification/discord/group.py`
- `app/notification/discord/host.py`
- `app/notification/discord/node.py`
- `app/notification/discord/user.py`
- `app/notification/discord/user_template.py`

## Verification

- [x] Ruff lint + format pass
- [x] 13/13 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized state persistence and notification system performance through streamlined data copying operations across core management and notification handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->