### PR TITLE
security: timing-safe HMAC and CORS wildcard fix

### DIFF
--- a/app/middlewares/__init__.py
+++ b/app/middlewares/__init__.py
@@ -9,10 +9,24 @@ from .request_logging import RequestProcessTimeLoggingMiddleware
 
 
 def setup_middleware(app: FastAPI):
+    # Security: reject wildcard origin with credentials enabled
+    allowed_origins = cors_settings.allowed_origins
+    if "*" in allowed_origins:
+        import warnings
+
+        warnings.warn(
+            "CORS allow_origins contains '*' with allow_credentials=True is insecure. "
+            "Set ALLOWED_ORIGINS to explicit origins in production.",
+            stacklevel=2,
+        )
+        allow_credentials = False
+    else:
+        allow_credentials = True
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=cors_settings.allowed_origins,
-        allow_credentials=True,
+        allow_origins=allowed_origins,
+        allow_credentials=allow_credentials,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/app/utils/jwt.py
+++ b/app/utils/jwt.py
@@ -1,3 +1,4 @@
+import hmac
 import time
 import jwt
 from base64 import b64decode, b64encode
@@ -38,7 +39,7 @@ async def get_admin_payload(token: str) -> dict | None:
         if admin_id is not None:
             try:
                 admin_id = int(admin_id)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 return
         if not username or access not in ("admin", "sudo"):
             return
@@ -97,7 +98,7 @@ async def get_subscription_payload(token: str) -> dict | None:
                 sha256((u_token + await get_secret_key()).encode("utf-8")).digest(), altchars=b"-_"
             ).decode("utf-8")[:10]
             u_token_hex_resign = sha256((u_token + await get_secret_key()).encode("utf-8")).hexdigest()[:10]
-            if u_signature in (u_token_resign, u_token_hex_resign):
+            if hmac.compare_digest(u_signature, u_token_resign) | hmac.compare_digest(u_signature, u_token_hex_resign):
                 parts = u_token_dec_str.split(",")
                 if len(parts) == 3 and parts[0] in ("v2", "v3"):
                     _, u_user_id_str, u_created_at_str = parts


### PR DESCRIPTION
## Changes

- **JWT timing-safe verification** (`app/utils/jwt.py`): Replaced `in` membership check with `hmac.compare_digest` using bitwise OR to ensure both comparisons always execute, preventing timing side-channels
- **CORS wildcard fix** (`app/middlewares/__init__.py`): When `allow_credentials=True`, any wildcard origin (`*`) in the allowed origins list now disables credentials with a warning
- **Python 2 syntax fix** (`app/utils/jwt.py`): Fixed `except TypeError, ValueError:` to `except (TypeError, ValueError):`

## What was removed (per project owner feedback)

- Rate limiting: Should be handled at infrastructure level (nginx, cloudflare, haproxy)
- TTL on `get_secret_key`: The JWT secret key is permanent and doesn't need a TTL
- `invalidate_secret_key_cache`: Unused function removed

## Files Changed

- `app/utils/jwt.py`
- `app/middlewares/__init__.py`

## Verification

- [x] Ruff lint + format pass
- [x] 13/13 tests pass
