### PR TITLE
fix(user-usage-notifications): clear data usage notification reminders after user data usage was reset

### DIFF
--- a/app/db/crud/user.py
+++ b/app/db/crud/user.py
@@ -1124,6 +1124,7 @@ async def reset_user_data_usage(
         User: The updated user object.
     """
     await _reset_user_traffic_and_log(db, db_user)
+    await delete_user_passed_notification_reminders(db, db_user.id, ReminderType.data_usage, 0)
     if clean_chart_data:
         await clear_user_node_usages(db, db_user.id)
 
@@ -1151,6 +1152,7 @@ async def bulk_reset_user_data_usage(
     """
     for db_user in users:
         await _reset_user_traffic_and_log(db, db_user)
+        await delete_user_passed_notification_reminders(db, db_user.id, ReminderType.data_usage, 0)
         if clean_chart_data:
             await clear_user_node_usages(db, db_user.id)
         if db_user.status not in [UserStatus.expired, UserStatus.disabled]:
@@ -1220,6 +1222,7 @@ async def reset_user_by_next(db: AsyncSession, db_user: User, *, clean_chart_dat
         db_user.data_limit_reset_strategy = db_user.next_plan.user_template.data_limit_reset_strategy
 
     await _reset_user_traffic_and_log(db, db_user)
+    await delete_user_passed_notification_reminders(db, db_user.id, ReminderType.data_usage, 0)
     if clean_chart_data:
         await clear_user_node_usages(db, db_user.id)
     db_user.status = UserStatus.active


### PR DESCRIPTION
### Conditions:
Suppose, we have users with no expiration date (`db_user.expire = None`) but with periodic traffic limit, such as 50 GB/month. Also, we set up webhook notifications on exceeding a user data usage threshhold, such as 90%.

### Expected behaviour:
When such user exceeds the threshhold, we get the webhook notification once. After the user data usage was reset either upon expiration of the traffic renewal period (month) or if the administrator renews the traffic/modifies the user, the SQL `notification_reminders` table is cleared of previous `data_usage` notifications and we get new notifiactions when the user exceeds the threshhold once again.

### Actual behaviour:
When the user exceeds the threshhold for the first time, we receive the notification once and  the `notification_reminders` table is filled filled with a record with `db_user.id`, `threshhold` and `expires_at = None` (see `usage_percent_notification_job`). After that, `delete_expired_reminders` never clears the `notification_reminders` for these users, so we never get the new notifiactions in the next time period. The `notification_reminders` table is cleared only when the `modify_user -> delete_user_passed_notification_reminders` functions are called when the administrator edits the user.

### Fix:
Call the `delete_user_passed_notification_reminders(db, db_user.id, ReminderType.data_usage, 0)` which clears all the `data_usage` remindes for that user every time when the  `db_user.used_traffic` was reset to 0.