### PR TITLE
Prevent Hysteria inbounds without TLS

### DIFF
--- a/app/core/xray.py
+++ b/app/core/xray.py
@@ -412,6 +412,15 @@ class XRayConfig(dict):
             self._read_inbound(inbound)
         self._protocols = _protocols_from_inbounds_by_tag(self._inbounds_by_tag)
 
+    @staticmethod
+    def _validate_hysteria_tls(protocol, stream, tag):
+        if protocol != "hysteria":
+            return
+        if not isinstance(stream, dict) or not stream:
+            raise ValueError(f"{tag} hysteria inbound requires TLS")
+        if stream.get("security") != "tls" or not isinstance(stream.get("tlsSettings"), dict):
+            raise ValueError(f"{tag} hysteria inbound requires TLS")
+
     def _read_inbound(self, inbound: dict):
         """Read an inbound and its settings."""
         if inbound["protocol"] not in ("vmess", "vless", "trojan", "shadowsocks", "hysteria"):
@@ -439,7 +448,10 @@ class XRayConfig(dict):
         if inbound["protocol"] == "shadowsocks":
             self._handle_shadowsocks_settings(inbound["settings"], settings)
 
-        if stream := inbound.get("streamSettings"):
+        stream = inbound.get("streamSettings")
+        self._validate_hysteria_tls(inbound["protocol"], stream, inbound["tag"])
+
+        if stream:
             net = stream.get("network", "tcp")
             net_settings = stream.get(f"{net}Settings", {})
             security = stream.get("security")

--- a/dashboard/src/features/core-editor/kit/inbound-form-options.ts
+++ b/dashboard/src/features/core-editor/kit/inbound-form-options.ts
@@ -72,7 +72,10 @@ export function getInboundTransportSelectOptions(
 
 export function getInboundSecuritySelectOptions(caps: InboundFormCapabilities, protocol: Inbound['protocol']): Array<'none' | 'tls' | 'reality'> {
   const all = Object.keys(caps.securities).filter((k): k is 'none' | 'tls' | 'reality' => caps.securities[k])
-  if (protocol === 'vmess' || protocol === 'shadowsocks' || protocol === 'hysteria') {
+  if (protocol === 'hysteria') {
+    return all.filter(s => s === 'tls')
+  }
+  if (protocol === 'vmess' || protocol === 'shadowsocks') {
     return all.filter(s => s !== 'reality')
   }
   return all

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from fastapi import status
 
 from app.core.xray import XRayConfig
@@ -383,3 +385,36 @@ def test_get_cores_simple_search_and_sort(access_token):
     finally:
         for core_id in created_core_ids:
             delete_core(access_token, core_id)
+
+
+def test_hysteria_inbound_requires_tls(access_token):
+    config = deepcopy(xray_config)
+    config["inbounds"] = [
+        {
+            "tag": "hy2-no-tls",
+            "listen": "0.0.0.0",
+            "port": 1081,
+            "protocol": "hysteria",
+            "settings": {"version": 2, "clients": []},
+            "streamSettings": {
+                "network": "hysteria",
+                "hysteriaSettings": {"version": 2},
+                "security": "none",
+            },
+        }
+    ]
+
+    response = client.post(
+        "/api/core",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={
+            "config": config,
+            "name": unique_name("hysteria_no_tls"),
+            "type": "xray",
+            "exclude_inbound_tags": [],
+            "fallbacks_inbound_tags": [],
+        },
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "hysteria inbound requires TLS" in response.json()["detail"]


### PR DESCRIPTION
Fixes #628

## Summary
- Reject Hysteria inbounds without TLS during Xray config parsing
- Hide the `none` security option for Hysteria in the dashboard
- Add an API regression test for Hysteria with `security: none`

## Tests
- `uv run pytest tests/api/test_core.py -k hysteria`
- `uv run pytest tests/api/test_core.py`
- `make check`
- `cd dashboard && bun run build`