### PR TITLE
feat(subscription): add InHive to default sing-box rule

### DIFF
--- a/app/db/migrations/versions/9af04c077ede_init_settings.py
+++ b/app/db/migrations/versions/9af04c077ede_init_settings.py
@@ -204,7 +204,7 @@ rules = [
         "target": "clash_meta",
     },
     {"pattern": r"^([Cc]lash|[Ss]tash)", "target": "clash"},
-    {"pattern": r"^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext)|.*[Ss]ing[\-b]?ox.*", "target": "sing_box"},
+    {"pattern": r"^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext|[Ii]n[Hh]ive)|.*[Ss]ing[\-b]?ox.*", "target": "sing_box"},
     {"pattern": r"^(SS|SSR|SSD|SSS|Outline|Shadowsocks|SSconf)", "target": "outline"},
     {
         "pattern": r"^.*",  # Default catch-all pattern


### PR DESCRIPTION
Adds InHive to the default sing-box rule in `app/db/migrations/versions/9af04c077ede_init_settings.py`:
```diff
- {"pattern": r"^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext)|.*[Ss]ing[\-b]?ox.*", "target": "sing_box"},
+ {"pattern": r"^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext|[Ii]n[Hh]ive)|.*[Ss]ing[\-b]?ox.*", "target": "sing_box"},
```
[InHive](https://inhive.ru) is a public sing-box-based client (releases at github.com/TwilgateLabs) supporting hysteria2/TUIC/Reality; UA `InHive/<ver> (<platform>; <hwid>)`. Its UA contains no `singbox` substring so the catch-all won't catch it — the explicit token is needed to route it to `sing_box`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded subscription routing detection so more app variants are matched during settings migration, including InHive alongside existing supported variants.
  * Improved case-insensitive matching for the updated app name pattern, helping routing rules apply more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->