### PR TITLE
feat(subscription): recognize InHive → xray (full config), not sing_box (#658 follow-up)

### DIFF
--- a/app/db/migrations/versions/9af04c077ede_init_settings.py
+++ b/app/db/migrations/versions/9af04c077ede_init_settings.py
@@ -204,7 +204,7 @@ rules = [
         "target": "clash_meta",
     },
     {"pattern": r"^([Cc]lash|[Ss]tash)", "target": "clash"},
-    {"pattern": r"^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext|[Ii]n[Hh]ive)|.*[Ss]ing[\-b]?ox.*", "target": "sing_box"},
+    {"pattern": r"^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext)|.*[Ss]ing[\-b]?ox.*", "target": "sing_box"},
     {"pattern": r"^(SS|SSR|SSD|SSS|Outline|Shadowsocks|SSconf)", "target": "outline"},
     {
         "pattern": r"^.*",  # Default catch-all pattern

--- a/app/db/migrations/versions/9af04c077ede_init_settings.py
+++ b/app/db/migrations/versions/9af04c077ede_init_settings.py
@@ -207,6 +207,12 @@ rules = [
     {"pattern": r"^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext)|.*[Ss]ing[\-b]?ox.*", "target": "sing_box"},
     {"pattern": r"^(SS|SSR|SSD|SSS|Outline|Shadowsocks|SSconf)", "target": "outline"},
     {
+        # InHive: universal client (sing-box fork + Xray parity); ingests raw
+        # share-links / Xray-JSON natively. Serve the full, unstripped xray format.
+        "pattern": r"^[Ii]n[Hh]ive",
+        "target": "xray",
+    },
+    {
         "pattern": r"^.*",  # Default catch-all pattern
         "target": "links_base64",
     },


### PR DESCRIPTION
Follow-up to my earlier merged PR #658, which added `[Ii]n[Hh]ive` to the default `sing_box` rule. That was the wrong target — the `sing_box` generator (`app/subscription/singbox.py`) drops kcp/xhttp/splithttp:

    if inbound.network in ("kcp", "splithttp", "xhttp"):
        return

InHive is a universal client (a sing-box fork with Xray-parity) that ingests raw share-links and Xray-JSON natively. This PR:
1. Removes `InHive` from the `sing_box` rule.
2. Adds an **explicit** `^[Ii]n[Hh]ive` → `xray` rule, so InHive is recognized by name and served the full Xray config (`app/subscription/xray.py` carries xhttp/splithttp, kcp, quic, reality, Hysteria2, WireGuard — no transport stripping).

This mirrors how Happ is handled elsewhere (recognized explicitly, served a full config) rather than relying on the catch-all.

**Notes**
- This migration seeds the **default** rules for fresh installs; operators who already migrated after #658 can adjust their `sing_box` rule from subscription settings.
- InHive sends an `X-HWID` header, so device-limit accounting is unchanged.
- Thanks for merging #658 and for reviewing this correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request routing for InHive and universal client connections.
  * InHive traffic is now directed to the Xray target, while Sing-box traffic continues to use its existing routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->