### PR TITLE
feat(dashboard): add InHive to default applications catalog

### DIFF
--- a/dashboard/src/features/subscriptions/components/default-applications-catalog.ts
+++ b/dashboard/src/features/subscriptions/components/default-applications-catalog.ts
@@ -59,6 +59,19 @@ const defaultApplicationsData: { operatingSystems: DefaultOperatingSystem[] } = 
       name: 'Android',
       apps: [
         {
+          name: 'InHive',
+          logo: 'https://cdn.jsdelivr.net/gh/TwilgateLabs/assets@main/inhive-logo.svg',
+          description:
+            'Invite-only universal VPN client built on a sing-box fork with Xray parity — VLESS(Reality), Hysteria2, TUIC, xHTTP, kcp, WireGuard. Uses per-install localhost auth.',
+          faDescription:
+            'کلاینت VPN جهانی مبتنی بر نسخه‌ی سفارشی sing-box با سازگاری Xray — VLESS(Reality)، Hysteria2، TUIC، xHTTP، kcp، WireGuard.',
+          ruDescription:
+            'Универсальный VPN‑клиент на форке sing-box с Xray‑совместимостью — VLESS(Reality), Hysteria2, TUIC, xHTTP, kcp, WireGuard. Аутентификация локального прокси per‑install.',
+          zhDescription: '基于 sing-box 分支并兼容 Xray 的通用 VPN 客户端 — VLESS(Reality)、Hysteria2、TUIC、xHTTP、kcp、WireGuard。',
+          configLink: 'inhive://import?sub={url}',
+          downloadLink: 'https://github.com/TwilgateLabs/inhive-android/releases/latest',
+        },
+        {
           name: 'V2rayNG',
           logo: 'https://raw.githubusercontent.com/2dust/v2rayNG/refs/heads/master/V2rayNG/app/src/main/ic_launcher-web.png',
           description: 'A V2Ray client for Android devices.',
@@ -83,6 +96,19 @@ const defaultApplicationsData: { operatingSystems: DefaultOperatingSystem[] } = 
     {
       name: 'Windows',
       apps: [
+        {
+          name: 'InHive',
+          logo: 'https://cdn.jsdelivr.net/gh/TwilgateLabs/assets@main/inhive-logo.svg',
+          description:
+            'Invite-only universal VPN client built on a sing-box fork with Xray parity — VLESS(Reality), Hysteria2, TUIC, xHTTP, kcp, WireGuard. Uses per-install localhost auth.',
+          faDescription:
+            'کلاینت VPN جهانی مبتنی بر نسخه‌ی سفارشی sing-box با سازگاری Xray — VLESS(Reality)، Hysteria2، TUIC، xHTTP، kcp، WireGuard.',
+          ruDescription:
+            'Универсальный VPN‑клиент на форке sing-box с Xray‑совместимостью — VLESS(Reality), Hysteria2, TUIC, xHTTP, kcp, WireGuard. Аутентификация локального прокси per‑install.',
+          zhDescription: '基于 sing-box 分支并兼容 Xray 的通用 VPN 客户端 — VLESS(Reality)、Hysteria2、TUIC、xHTTP、kcp、WireGuard。',
+          configLink: 'inhive://import?sub={url}',
+          downloadLink: 'https://github.com/TwilgateLabs/inhive-windows/releases/latest',
+        },
         {
           name: 'V2rayN',
           logo: 'https://raw.githubusercontent.com/2dust/v2rayN/refs/heads/master/v2rayN/v2rayN.Desktop/v2rayN.png',


### PR DESCRIPTION
Adds **InHive** to the default applications catalog (Android + Windows), so operators' subscription pages list it as a supported client.

InHive is a universal VPN client — a sing-box fork with Xray parity (VLESS/Reality, Hysteria2, TUIC, xHTTP, kcp, WireGuard). It registers the `inhive://import?sub={url}` deep-link for one-tap subscription import (Android manifest + iOS URL scheme).

- Logo served from a CDN (jsdelivr over a public GitHub repo), so it stays available and vector-crisp.
- Download links point to the public TwilgateLabs release pages.
- Companion to #689 (routing InHive to the full `xray` config).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added InHive to the default applications catalog for Android and Windows.
  * Included localized descriptions, app icons, subscription configuration links, and platform-specific download links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->