### PR TITLE
fix(subscription): emit sni instead of servername for hysteria2 in clash-meta config

### DIFF
--- a/app/subscription/clash.py
+++ b/app/subscription/clash.py
@@ -381,7 +381,7 @@ class ClashConfiguration(BaseSubscription):
         node["tls"] = True
         sni = tls_config.sni if isinstance(tls_config.sni, str) else ""
 
-        if protocol == "trojan":
+        if protocol in ("trojan", "hysteria"):
             node["sni"] = sni
         else:
             node["servername"] = sni

--- a/tests/test_subscription_clash_hysteria.py
+++ b/tests/test_subscription_clash_hysteria.py
@@ -1,0 +1,50 @@
+from app.models.subscription import SubscriptionInboundData, TCPTransportConfig, TLSConfig
+from app.subscription.clash import ClashMetaConfiguration
+
+
+USER_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _inbound(protocol: str, network: str = "tcp") -> SubscriptionInboundData:
+    return SubscriptionInboundData(
+        remark=protocol,
+        inbound_tag=f"{protocol}-inbound",
+        protocol=protocol,
+        address="edge.example.com",
+        port=443,
+        network=network,
+        tls_config=TLSConfig(tls="tls", sni="cert.example.com"),
+        transport_config=TCPTransportConfig(),
+        priority=0,
+    )
+
+
+def test_clash_meta_hysteria2_uses_sni_not_servername():
+    meta = ClashMetaConfiguration()
+    meta.add("meta hysteria", "edge.example.com", _inbound("hysteria"), {"auth": "auth-password"})
+
+    assert len(meta.data["proxies"]) == 1
+    node = meta.data["proxies"][0]
+    assert node["type"] == "hysteria2"
+    assert node["sni"] == "cert.example.com"
+    assert "servername" not in node
+
+
+def test_clash_meta_trojan_still_uses_sni():
+    meta = ClashMetaConfiguration()
+    meta.add("meta trojan", "edge.example.com", _inbound("trojan"), {"password": "trojan-password"})
+
+    node = meta.data["proxies"][0]
+    assert node["type"] == "trojan"
+    assert node["sni"] == "cert.example.com"
+    assert "servername" not in node
+
+
+def test_clash_meta_vless_still_uses_servername():
+    meta = ClashMetaConfiguration()
+    meta.add("meta vless", "edge.example.com", _inbound("vless"), {"id": USER_ID})
+
+    node = meta.data["proxies"][0]
+    assert node["type"] == "vless"
+    assert node["servername"] == "cert.example.com"
+    assert "sni" not in node


### PR DESCRIPTION
## Summary

Hysteria2 proxies in the Clash.Meta subscription are generated with the TLS server name in the `servername` field. mihomo does not read `servername` for `type: hysteria2` - it only reads `sni` ([docs](https://wiki.metacubex.one/en/config/proxies/hysteria2/), [`Hysteria2Option` source](https://github.com/MetaCubeX/mihomo/blob/Alpha/adapter/outbound/hysteria2.go) - the only servername field is `SNI` with tag `proxy:"sni"`; `servername` is used by vmess/vless). As a result, when the host address is an IP, mihomo validates the certificate against the raw IP and the node fails with:

```
x509: cannot validate certificate for <server IP> because it doesn't contain any IP SANs
```

**Fix:** in `ClashConfiguration._apply_tls`, emit `sni` for both `trojan` and `hysteria` protocols (previously trojan only); vmess/vless keep `servername`. `ClashMetaConfiguration._apply_tls` delegates to the base method, so it is covered too. The legacy `ClashConfiguration` is unaffected - it does not register a hysteria handler.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed. (not needed)
- [x] I checked database migrations when models or schema changed. (no schema changes)
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

- Added `tests/test_subscription_clash_hysteria.py`:
  - hysteria2 node gets `sni` from the inbound TLS config and has no `servername` key;
  - regression: trojan still gets `sni`, vless still gets `servername`.
- `pytest tests/` (subscription tests) - pass; `ruff check` / `ruff format` - clean.
- Verified against a live mihomo client: with `servername` the node fails with the x509 error above; with `sni` it connects.

## Screenshots

N/A (config generation only, no UI changes).

## Notes for reviewers

- One-line change in `app/subscription/clash.py` plus a new test file; no model or schema changes.
- Side note, out of scope for this PR: in `_build_hysteria`, `hop-interval` is effectively never emitted - the value is built from `udpHop.hopInterval` but the condition checks `udpHop.interval`, and even when set it produces a string like `"30s"` while mihomo expects an integer. The singbox generator handles both keys. Happy to file a separate issue.
