### PR TITLE
fix: update download_settings host changes without re-saving the main host

### DIFF
--- a/app/operation/host.py
+++ b/app/operation/host.py
@@ -95,7 +95,13 @@ class HostOperation(BaseOperation):
         host = BaseHost.model_validate(db_host)
         asyncio.create_task(notification.modify_host(host, admin.username))
 
-        await host_manager.add_host(db, db_host)
+        db_hosts = await get_hosts(db=db)
+        dependents = [
+            h
+            for h in db_hosts
+            if ((h.transport_settings or {}).get("xhttp_settings") or {}).get("download_settings") == host_id
+        ]
+        await host_manager.add_hosts(db, [db_host, *dependents])
 
         return host
 


### PR DESCRIPTION
## Summary

When a host is used as another host's xhttp download_settings, editing that host alone did not update the main host's cached data. Now, saving a host also refreshes every host that points to it as their download_settings.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated documentation, translations, or examples if needed.
- [ ] I checked database migrations when models or schema changed.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.