### PR TITLE
fix: redirect authenticated users away from /login

### DIFF
--- a/dashboard/src/pages/login.tsx
+++ b/dashboard/src/pages/login.tsx
@@ -8,9 +8,9 @@ import { Input } from '@/components/ui/input'
 import { LoaderButton } from '@/components/ui/loader-button'
 import { PasswordInput } from '@/components/ui/password-input'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { useAdminMiniAppToken, useAdminToken, useCreateOwner, useDeleteOwner, useResetOwnerPassword, useUpgradeOwner } from '@/service/api'
+import { getCurrentAdmin, useAdminMiniAppToken, useAdminToken, useCreateOwner, useDeleteOwner, useResetOwnerPassword, useUpgradeOwner } from '@/service/api'
 import { $fetch } from '@/service/http'
-import { removeAuthToken, setAuthToken } from '@/utils/authStorage'
+import { getAuthToken, removeAuthToken, setAuthToken } from '@/utils/authStorage'
 import { queryClient } from '@/utils/query-client'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { retrieveRawInitData } from '@telegram-apps/sdk'
@@ -129,18 +129,6 @@ export const Login: FC = () => {
     resolver: zodResolver(schema),
   })
 
-  useEffect(() => {
-    // Cancel all ongoing queries first to stop any in-flight requests
-    queryClient.cancelQueries()
-    // Remove the auth token
-    removeAuthToken()
-    // Clear all React Query cache to ensure fresh state after logout
-    queryClient.clear()
-    if (location.pathname !== '/login') {
-      navigate('/login', { replace: true })
-    }
-  }, [location.pathname, navigate])
-
   let isTelegram = false
   let initDataRaw = ''
   try {
@@ -150,6 +138,35 @@ export const Login: FC = () => {
     isTelegram = false
     initDataRaw = ''
   }
+
+  useEffect(() => {
+    if (location.pathname !== '/login') {
+      navigate('/login', { replace: true })
+    }
+  }, [location.pathname, navigate])
+
+  useEffect(() => {
+    // The Telegram MiniApp flow below owns its own auth exchange - let it run
+    // undisturbed rather than racing it over the stored token.
+    if (isTelegram) return
+    // No token: nothing to verify, show the login form
+    if (!getAuthToken()) return
+
+    // A token exists - check whether it's still valid before deciding
+    // whether to redirect to the dashboard or drop the stale session
+    getCurrentAdmin()
+      .then(() => {
+        navigate('/', { replace: true })
+      })
+      .catch(() => {
+        // Cancel all ongoing queries first to stop any in-flight requests
+        queryClient.cancelQueries()
+        // Remove the auth token
+        removeAuthToken()
+        // Clear all React Query cache to ensure fresh state after logout
+        queryClient.clear()
+      })
+  }, [navigate, isTelegram])
 
   const {
     mutate: login,

--- a/dashboard/src/pages/login.tsx
+++ b/dashboard/src/pages/login.tsx
@@ -149,16 +149,27 @@ export const Login: FC = () => {
     // The Telegram MiniApp flow below owns its own auth exchange - let it run
     // undisturbed rather than racing it over the stored token.
     if (isTelegram) return
+
+    const token = getAuthToken()
     // No token: nothing to verify, show the login form
-    if (!getAuthToken()) return
+    if (!token) return
+
+    const controller = new AbortController()
 
     // A token exists - check whether it's still valid before deciding
     // whether to redirect to the dashboard or drop the stale session
-    getCurrentAdmin()
+    getCurrentAdmin(controller.signal)
       .then(() => {
         navigate('/', { replace: true })
       })
-      .catch(() => {
+      .catch((error: any) => {
+        if (error?.name === 'AbortError') return
+        // Another flow (e.g. a manual login) already replaced the token - don't clobber it
+        if (getAuthToken() !== token) return
+        // Only drop the session on a confirmed auth failure; transient/network
+        // errors shouldn't log out an otherwise-valid session
+        if (error?.status !== 401 && error?.status !== 403) return
+
         // Cancel all ongoing queries first to stop any in-flight requests
         queryClient.cancelQueries()
         // Remove the auth token
@@ -166,6 +177,8 @@ export const Login: FC = () => {
         // Clear all React Query cache to ensure fresh state after logout
         queryClient.clear()
       })
+
+    return () => controller.abort()
   }, [navigate, isTelegram])
 
   const {


### PR DESCRIPTION
The login page unconditionally cleared the auth token and query cache on every mount, forcing a re-login even when a valid session already existed. It now checks the stored token with getCurrentAdmin() (the same check the dashboard route loader uses) and redirects to the dashboard if it's still valid, only clearing the session when it's missing or invalid. The check is skipped for the Telegram MiniApp flow, which manages its own auth token independently.

## Summary

<!-- What changed and why? Keep this short and specific. -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests / CI

## Checklist

- [ ] I tested the change locally or explained why it cannot be tested.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated documentation, translations, or examples if needed.
- [ ] I checked database migrations when models or schema changed.
- [X] I did not include secrets, tokens, private keys, or unrelated changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login-session behavior when navigating to and from the login page.
  * Automatically redirects already-authenticated users to the dashboard.
  * Safely validates any stored token before proceeding, with reliable handling of aborted requests.
  * Cleans up invalid/expired sessions (canceling active requests and clearing cached data) only when access is rejected.
  * Kept the existing Telegram MiniApp authentication flow unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->