### PR TITLE
feat(subscription): add external custom configs

### DIFF
--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -321,6 +321,7 @@ class Subscription(BaseModel):
     allow_browser_config: bool = Field(default=True)
     disable_sub_template: bool = Field(default=False)
     randomize_order: bool = Field(default=False)
+    external_config: str = Field(default="", max_length=65535)
     custom_variables: list[CustomVariable] = Field(default_factory=list)
 
     @field_validator("custom_variables")

--- a/app/subscription/links.py
+++ b/app/subscription/links.py
@@ -14,7 +14,6 @@ from app.models.subscription import (
     WebSocketTransportConfig,
     XHTTPTransportConfig,
 )
-from config import subscription_env_settings
 
 from . import BaseSubscription
 
@@ -61,8 +60,6 @@ class StandardLinks(BaseSubscription):
         self.links.append(link)
 
     def render(self):
-        if subscription_env_settings.external_config:
-            self.links.append(subscription_env_settings.external_config)
         return "\n".join(self.links)
 
     def add(self, remark: str, address: str, inbound: SubscriptionInboundData, settings: dict):

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -15,6 +15,7 @@ from app.models.user import UsersResponseWithInbounds
 from app.settings import subscription_settings
 from app.subscription.client_templates import subscription_client_templates, subscription_xray_templates
 from app.utils.system import readable_size
+from config import subscription_env_settings
 
 from . import (
     ClashConfiguration,
@@ -103,10 +104,36 @@ async def generate_subscription(
         custom_variables=custom_variables,
     )
 
+    if config_format == "links" and isinstance(config, str):
+        external_configs = _format_external_configs(
+            subscription_env_settings.external_config,
+            sub_settings.external_config,
+            format_variables=format_variables,
+        )
+        if external_configs:
+            config = "\n".join(part for part in (config, *external_configs) if part)
+
     if as_base64 and not isinstance(config, bytes):
         config = base64.b64encode(config.encode()).decode()
 
     return config
+
+
+def _format_external_configs(
+    *values: str | None,
+    format_variables: dict,
+) -> list[str]:
+    """Normalize external share links and apply subscription variables per line."""
+    configs: list[str] = []
+    for value in values:
+        for line in (value or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            formatted = _format_dynamic_value(line, format_variables)
+            if formatted:
+                configs.append(formatted)
+    return configs
 
 
 def format_time_left(seconds_left: int) -> str:

--- a/dashboard/public/statics/locales/en.json
+++ b/dashboard/public/statics/locales/en.json
@@ -262,6 +262,8 @@
         "announceUrl": "Announcement URL",
         "announceUrlPlaceholder": "https://status.example.com",
         "announceUrlDescription": "Optional link with more information about the announcement",
+        "externalConfig": "External Configurations",
+        "externalConfigDescription": "Share links added to plain-text and Base64 link subscriptions, one per line. Supports template variables.",
         "allowBrowserConfig": "Show Links in Subscription Page",
         "allowBrowserConfigDescription": "Display subscription links on the subscription page template when accessed via browser",
         "disableSubTemplate": "Disable Subscription Template",

--- a/dashboard/public/statics/locales/fa.json
+++ b/dashboard/public/statics/locales/fa.json
@@ -131,6 +131,8 @@
         "announceUrl": "آدرس اطلاعیه",
         "announceUrlPlaceholder": "https://status.example.com",
         "announceUrlDescription": "لینک اختیاری برای جزئیات بیشتر اطلاعیه",
+        "externalConfig": "کانفیگ‌های خارجی",
+        "externalConfigDescription": "لینک‌های اشتراک خارجی را هر کدام در یک خط به خروجی لینک ساده و Base64 اضافه کنید. متغیرهای قالب پشتیبانی می‌شوند.",
         "allowBrowserConfig": "نمایش لینک‌ها در صفحه اشتراک",
         "allowBrowserConfigDescription": "نمایش لینک‌های اشتراک در قالب صفحه اشتراک هنگام دسترسی از طریق مرورگر",
         "disableSubTemplate": "غیرفعال کردن قالب اشتراک",

--- a/dashboard/public/statics/locales/ru.json
+++ b/dashboard/public/statics/locales/ru.json
@@ -280,6 +280,8 @@
         "announceUrl": "Ссылка на объявление",
         "announceUrlPlaceholder": "https://status.example.com",
         "announceUrlDescription": "Необязательная ссылка с дополнительной информацией об объявлении",
+        "externalConfig": "Внешние конфигурации",
+        "externalConfigDescription": "Добавьте внешние ссылки по одной в строке в обычные и Base64-подписки. Поддерживаются переменные шаблона.",
         "allowBrowserConfig": "Показывать ссылки на странице подписки",
         "allowBrowserConfigDescription": "Отображать ссылки подписки в шаблоне страницы подписки при доступе через браузер",
         "disableSubTemplate": "Отключить шаблон подписки",

--- a/dashboard/public/statics/locales/zh.json
+++ b/dashboard/public/statics/locales/zh.json
@@ -246,6 +246,8 @@
         "announceUrl": "公告链接",
         "announceUrlPlaceholder": "https://status.example.com",
         "announceUrlDescription": "可选的链接，用于提供更多公告细节",
+        "externalConfig": "外部配置",
+        "externalConfigDescription": "每行添加一个外部分享链接到纯文本和 Base64 链接订阅。支持模板变量。",
         "allowBrowserConfig": "在订阅页面显示链接",
         "allowBrowserConfigDescription": "当通过浏览器访问时，在订阅页面模板中显示订阅链接",
         "disableSubTemplate": "禁用订阅模板",

--- a/dashboard/src/features/subscriptions/components/subscription-general-settings-section.tsx
+++ b/dashboard/src/features/subscriptions/components/subscription-general-settings-section.tsx
@@ -146,6 +146,28 @@ export function SubscriptionGeneralSettingsSection({ form }: SubscriptionGeneral
 
         <FormField
           control={form.control}
+          name="external_config"
+          render={({ field }) => (
+            <FormItem className="space-y-2 lg:col-span-2">
+              <div className="flex items-center gap-1.5">
+                <FormLabel className="flex items-center gap-2 text-xs font-medium sm:text-sm">
+                  <Link className="h-4 w-4 shrink-0" />
+                  {t('settings.subscriptions.general.externalConfig')}
+                </FormLabel>
+                <VariablesPopover customVariables={form.watch('custom_variables') || []} />
+                <CustomVariablesPopover customVariables={form.watch('custom_variables') || []} />
+              </div>
+              <FormControl>
+                <Textarea placeholder={'vless://...\nss://...\ntrojan://...'} rows={5} className="font-mono text-xs sm:text-sm" {...field} />
+              </FormControl>
+              <FormDescription className="text-muted-foreground text-xs sm:text-sm">{t('settings.subscriptions.general.externalConfigDescription')}</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
           name="allow_browser_config"
           render={({ field }) => (
             <FormItem className="bg-card hover:bg-accent/50 flex flex-row items-center justify-between space-y-0 rounded-lg border p-3 transition-colors sm:p-4 lg:col-span-2">

--- a/dashboard/src/features/subscriptions/components/subscription-settings-schema.ts
+++ b/dashboard/src/features/subscriptions/components/subscription-settings-schema.ts
@@ -106,6 +106,7 @@ export const subscriptionSchema = z.object({
   allow_browser_config: z.boolean().optional(),
   disable_sub_template: z.boolean().optional(),
   randomize_order: z.boolean().optional(),
+  external_config: z.string().max(65535, 'External configurations must be 65535 characters or less').optional(),
   custom_variables: customVariablesSchema,
   response_headers: z.record(z.string()).optional(),
   rules: z.array(

--- a/dashboard/src/pages/_dashboard.settings.subscriptions.tsx
+++ b/dashboard/src/pages/_dashboard.settings.subscriptions.tsx
@@ -8,7 +8,13 @@ import { SubscriptionManualFormatsSection } from '@/features/subscriptions/compo
 import { SubscriptionResponseHeadersSection } from '@/features/subscriptions/components/subscription-response-headers-section'
 import { SubscriptionRulesSection } from '@/features/subscriptions/components/subscription-rules-section'
 import { SubscriptionSettingsSkeleton } from '@/features/subscriptions/components/subscription-settings-skeleton'
-import { subscriptionSchema, type SubscriptionApplicationFormData, type SubscriptionFormData, defaultSubscriptionRules, normalizeCustomVariablesForPayload } from '@/features/subscriptions/components/subscription-settings-schema'
+import {
+  subscriptionSchema,
+  type SubscriptionApplicationFormData,
+  type SubscriptionFormData,
+  defaultSubscriptionRules,
+  normalizeCustomVariablesForPayload,
+} from '@/features/subscriptions/components/subscription-settings-schema'
 import { Form } from '@/components/ui/form'
 import { Separator } from '@/components/ui/separator'
 import { type SubRule as ApiSubRule } from '@/service/api'
@@ -38,6 +44,7 @@ export default function SubscriptionSettings() {
       allow_browser_config: true,
       disable_sub_template: false,
       randomize_order: false,
+      external_config: '',
       custom_variables: [],
       response_headers: {},
       rules: [],
@@ -122,6 +129,7 @@ export default function SubscriptionSettings() {
         allow_browser_config: subscriptionData.allow_browser_config ?? true,
         disable_sub_template: subscriptionData.disable_sub_template ?? false,
         randomize_order: subscriptionData.randomize_order ?? false,
+        external_config: subscriptionData.external_config || '',
         custom_variables: subscriptionData.custom_variables || [],
         response_headers: Object.fromEntries(Object.entries(subscriptionData.response_headers || {}).map(([key, value]) => [key, typeof value === 'string' ? value : JSON.stringify(value)])),
         rules:
@@ -204,6 +212,7 @@ export default function SubscriptionSettings() {
           profile_title: data.profile_title?.trim() || undefined,
           announce: data.announce?.trim() || undefined,
           announce_url: data.announce_url?.trim() || undefined,
+          external_config: data.external_config?.trim() || undefined,
           custom_variables: processedCustomVariables,
           response_headers: processedResponseHeaders,
           rules: processedRules,
@@ -281,6 +290,7 @@ export default function SubscriptionSettings() {
         allow_browser_config: subscriptionData.allow_browser_config ?? true,
         disable_sub_template: subscriptionData.disable_sub_template ?? false,
         randomize_order: subscriptionData.randomize_order ?? false,
+        external_config: subscriptionData.external_config || '',
         custom_variables: subscriptionData.custom_variables || [],
         response_headers: Object.fromEntries(Object.entries(subscriptionData.response_headers || {}).map(([key, value]) => [key, typeof value === 'string' ? value : JSON.stringify(value)])),
         rules:

--- a/dashboard/src/service/api/index.ts
+++ b/dashboard/src/service/api/index.ts
@@ -1434,6 +1434,8 @@ export interface Subscription {
   allow_browser_config?: boolean
   disable_sub_template?: boolean
   randomize_order?: boolean
+  /** @maxLength 65535 */
+  external_config?: string
   custom_variables?: CustomVariable[]
 }
 

--- a/tests/api/test_settings.py
+++ b/tests/api/test_settings.py
@@ -36,3 +36,27 @@ def test_general_settings_custom_variables_round_trip(access_token):
             json={"subscription": original_subscription},
         )
         assert restore_response.status_code == status.HTTP_200_OK
+
+
+def test_subscription_external_config_round_trip(access_token):
+    settings_response = client.get("/api/settings", headers=auth_headers(access_token))
+    assert settings_response.status_code == status.HTTP_200_OK
+    original_subscription = settings_response.json()["subscription"]
+    external_config = "vless://external.example#one\nss://external.example"
+
+    try:
+        update_response = client.put(
+            "/api/settings",
+            headers=auth_headers(access_token),
+            json={"subscription": {**original_subscription, "external_config": external_config}},
+        )
+
+        assert update_response.status_code == status.HTTP_200_OK
+        assert update_response.json()["subscription"]["external_config"] == external_config
+    finally:
+        restore_response = client.put(
+            "/api/settings",
+            headers=auth_headers(access_token),
+            json={"subscription": original_subscription},
+        )
+        assert restore_response.status_code == status.HTTP_200_OK

--- a/tests/test_subscription_external_config.py
+++ b/tests/test_subscription_external_config.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from app.models.settings import Subscription
+from app.subscription.share import _format_external_configs
+
+
+def test_external_configs_are_trimmed_formatted_and_keep_order():
+    configs = _format_external_configs(
+        "  vless://legacy.example#{USERNAME}  \n\nss://legacy.example  ",
+        "trojan://{USERNAME}@external.example\n  hysteria2://external.example  ",
+        format_variables={"USERNAME": "alice"},
+    )
+
+    assert configs == [
+        "vless://legacy.example#alice",
+        "ss://legacy.example",
+        "trojan://alice@external.example",
+        "hysteria2://external.example",
+    ]
+
+
+def test_external_configs_leave_invalid_format_strings_unchanged():
+    configs = _format_external_configs(
+        "vless://external.example#{unclosed",
+        format_variables={"USERNAME": "alice"},
+    )
+
+    assert configs == ["vless://external.example#{unclosed"]
+
+
+def test_subscription_external_config_has_a_size_limit():
+    with pytest.raises(ValidationError):
+        Subscription(rules=[], external_config="x" * 65536)


### PR DESCRIPTION
## Summary

Adds support for appending externally managed share links to generated subscriptions.

- Adds an External Configurations field to subscription settings.
- Supports multiple external links, one per line.
- Appends external links to plain-text and Base64 subscriptions.
- Supports subscription template variables such as `{USERNAME}`.
- Preserves backward compatibility with the `EXTERNAL_CONFIG` environment variable.
- Adds English, Persian, Russian, and Chinese translations.

Closes #683

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed.
- [x] I checked database migrations when models or schema changed.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

- `uv run pytest -q tests/test_subscription_external_config.py` — 3 passed.
- Ruff checks passed for the changed backend and test files.
- TypeScript type checking completed successfully.
- JSON validation passed for all four modified locale files.
- A full dashboard build could not be completed in the validation environment because the installed `@pasarguard/core-kit` package did not contain its expected `dist` output.

No database migration is required because this setting is stored in the existing JSON settings structure.

## Screenshots

Not available. The change adds a multiline External Configurations field to the existing subscription settings form.

## Notes for reviewers

External links are intentionally appended only to `links` and `links_base64` outputs. Raw share links cannot safely be appended directly to structured Xray, Clash, or Sing-box JSON/YAML outputs.

Existing installations using the `EXTERNAL_CONFIG` environment variable remain supported.