### PR TITLE
Enforce the role group allowance when users are created and modified

### DIFF
--- a/app/operation/__init__.py
+++ b/app/operation/__init__.py
@@ -24,7 +24,7 @@ from app.db.models import Admin as DBAdmin, ClientTemplate, CoreConfig, Group, N
 from app.models.admin import AdminDetails
 from app.models.group import BulkGroup
 from app.models.user import UserCreate, UserModify
-from app.operation.permissions import get_scope_admin_id
+from app.operation.permissions import get_allowed_group_ids, get_scope_admin_id
 from app.utils.helpers import ensure_datetime_timezone
 from app.utils.jwt import get_subscription_payload
 
@@ -227,7 +227,22 @@ class BaseOperation:
             await self.raise_error("Group not found", 404)
         return db_group
 
-    async def validate_all_groups(self, db, model: UserCreate | UserModify | UserTemplate | BulkGroup) -> list[Group]:
+    async def validate_all_groups(
+        self,
+        db,
+        model: UserCreate | UserModify | UserTemplate | BulkGroup,
+        admin: AdminDetails | None = None,
+        exempt_group_ids: set[int] | None = None,
+    ) -> list[Group]:
+        """Resolve requested group ids, refusing any the admin may not use.
+
+        `admin` is optional because some callers resolve groups only in order to
+        display them; the access check applies wherever an acting admin is given.
+
+        `exempt_group_ids` are groups already present on the record being
+        edited. They pass even when the admin could not grant them, so that an
+        unrelated edit is not blocked by state the admin never chose.
+        """
         requested_group_ids: list[int] = []
         if model.group_ids:
             requested_group_ids.extend(model.group_ids)
@@ -244,6 +259,16 @@ class BaseOperation:
         missing_ids = [group_id for group_id in unique_ids if group_id not in groups_by_id]
         if missing_ids:
             await self.raise_error("Group not found", 404)
+
+        # The same allowance the group listing is filtered by, so what an admin
+        # can be offered and what they can actually assign cannot drift apart.
+        if admin is not None:
+            allowed_group_ids = get_allowed_group_ids(admin)
+            if allowed_group_ids is not None:
+                allowed = set(allowed_group_ids) | set(exempt_group_ids or ())
+                forbidden = sorted(groups_by_id[gid].name for gid in unique_ids if gid not in allowed)
+                if forbidden:
+                    await self.raise_error(f"You are not allowed to use these groups: {', '.join(forbidden)}", 403)
 
         # Preserve the requested order and duplicate semantics.
         return [groups_by_id[group_id] for group_id in requested_group_ids]

--- a/app/operation/user.py
+++ b/app/operation/user.py
@@ -672,7 +672,7 @@ class UserOperation(BaseOperation):
         if new_user.next_plan is not None and new_user.next_plan.user_template_id is not None:
             await self.get_validated_user_template(db, new_user.next_plan.user_template_id)
 
-        all_groups = await self.validate_all_groups(db, new_user)
+        all_groups = await self.validate_all_groups(db, new_user, admin)
         db_admin = await get_admin(db, admin.username, load_users=False, load_usage_logs=False)
         # peer IPs are never taken from input; the subnet pool assigns them at creation
         new_user.proxy_settings.wireguard.peer_ips = []
@@ -794,7 +794,9 @@ class UserOperation(BaseOperation):
 
         validated_groups = None
         if modified_user.group_ids is not None:
-            validated_groups = await self.validate_all_groups(db, modified_user)
+            validated_groups = await self.validate_all_groups(
+                db, modified_user, admin, exempt_group_ids={group.id for group in db_user.groups}
+            )
 
         if modified_user.next_plan is not None and modified_user.next_plan.user_template_id is not None:
             await self.get_validated_user_template(db, modified_user.next_plan.user_template_id)
@@ -1775,7 +1777,7 @@ class UserOperation(BaseOperation):
 
         groups: list = []
         if users_to_create:
-            groups = await self.validate_all_groups(db, users_to_create[0])
+            groups = await self.validate_all_groups(db, users_to_create[0], admin)
 
         db_admin = await get_admin(db, admin.username, load_users=False, load_usage_logs=False)
         try:


### PR DESCRIPTION
### What

`RoleAccess.allowed_group_ids` is not consulted when a user is created or modified, so an admin whose role restricts them to a subset of groups can still assign any group by calling the API directly.

### Why this looks like a gap rather than intended behaviour

The allowance is already enforced in `app/operation/group.py` in five places — `get_all_groups`, `get_groups_simple`, `_get_group_with_access`, `bulk_remove_groups_by_id`, `bulk_set_groups_disabled` — all via `apply_group_access`. So a restricted admin cannot list, fetch, or bulk-modify a group outside their allowance.

But `validate_all_groups` in `app/operation/__init__.py`, which every user write path resolves groups through, only checks that the requested groups **exist**:

```python
missing_ids = [group_id for group_id in unique_ids if group_id not in groups_by_id]
if missing_ids:
    await self.raise_error("Group not found", 404)

return [groups_by_id[group_id] for group_id in requested_group_ids]
```

The result is that the restriction holds in the dashboard, because the group never appears in the picker, but not against a direct request:

```
POST /api/user   {"username": "...", "group_ids": [<id outside the allowance>]}
→ 201 Created
```

### The change

`validate_all_groups` now takes an optional acting admin and applies `get_allowed_group_ids` — the same function the listing is filtered by, so what an admin can be offered and what they can assign cannot drift apart. It is the single point `create_user`, `modify_user` and `bulk_create_users_from_template` all resolve groups through (and the Telegram handlers by way of those), so one check covers every write path.

The argument is optional because a few callers resolve groups only in order to render them; enforcement applies wherever an acting admin is passed. Owners are unaffected, and an admin with no restriction is unaffected.

### The exemption, and why it is needed

Groups already present on the user being edited are exempt from the check.

Without it, restricting a role would stop its admins from saving **any** edit to a user who happens to sit in a group outside the allowance — not just group changes, but the data limit, the expiry, anything — because the edit form loads the user's current groups and posts them back unchanged. The check would then be refusing the state that was already there rather than the change being made.

Adding such a group is still refused, including adding it back after removing it.

### Testing

Verified against a running panel with a role limited to one group and an admin with no per-admin restriction:

- the group listing is filtered to the allowed group
- `POST /api/user` with a group outside the allowance → `403 You are not allowed to use these groups: <name>`
- a mix of one allowed and one forbidden group → `403`
- the allowed group → `201`
- a user already holding a forbidden group can still be edited
- that group can be removed, and cannot be added back afterwards
- owners are unaffected

The panel's existing test suite passes unchanged (501 passed, 2 skipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group assignment validation during user creation, updates, and bulk template operations.
  * Administrators can now assign only permitted groups, while approved exemptions remain available.
  * Unauthorized group assignments now return a clear access-denied error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->