### PR TITLE
Allow the group allowance to be set per admin, not only per role

### DIFF
--- a/app/db/crud/admin.py
+++ b/app/db/crud/admin.py
@@ -100,6 +100,7 @@ def build_admin_details(
         permission_overrides=RoleLimits.model_validate(db_admin.permission_overrides)
         if db_admin.permission_overrides
         else None,
+        allowed_group_ids=db_admin.allowed_group_ids,
     )
 
 
@@ -228,6 +229,10 @@ async def update_admin(db: AsyncSession, db_admin: Admin, modified_admin: AdminM
         db_admin.note = modified_admin.note
     if modified_admin.notification_enable is not None:
         db_admin.notification_enable = modified_admin.notification_enable.model_dump()
+    # Unlike the fields above, null is meaningful here - it lifts the
+    # restriction - so go by whether the caller sent the field at all.
+    if "allowed_group_ids" in modified_admin.model_fields_set:
+        db_admin.allowed_group_ids = modified_admin.allowed_group_ids
 
     await db.commit()
     await db.refresh(db_admin)

--- a/app/db/migrations/versions/d1f4a92c7e08_add_per_admin_allowed_group_ids.py
+++ b/app/db/migrations/versions/d1f4a92c7e08_add_per_admin_allowed_group_ids.py
@@ -1,0 +1,35 @@
+"""add per-admin allowed group ids
+
+Revision ID: d1f4a92c7e08
+Revises: fb32155473c1
+Create Date: 2026-08-08 18:20:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "d1f4a92c7e08"
+down_revision = "fb32155473c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # NULL means unrestricted, so every existing admin keeps whatever their
+    # role already allows and nothing changes until the field is set.
+    with op.batch_alter_table("admins", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "allowed_group_ids",
+                sa.JSON().with_variant(JSONB(none_as_null=True), "postgresql"),
+                nullable=True,
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("admins", schema=None) as batch_op:
+        batch_op.drop_column("allowed_group_ids")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -109,6 +109,9 @@ class Admin(Base, CreatedAtUTCMixin):
     role_id: Mapped[int] = fk_id_column("admin_roles.id", default=0)
     role: Mapped[AdminRole | None] = relationship(back_populates="admins", init=False, lazy="select")
     permission_overrides: Mapped[dict | None] = mapped_column(PostgresJSONB, default=None)
+    # NULL means every group the admin's role allows. A list narrows that
+    # further, to these group ids and nothing else.
+    allowed_group_ids: Mapped[list[int] | None] = mapped_column(PostgresJSONB, default=None)
 
     @hybrid_property
     def is_disabled(self) -> bool:

--- a/app/models/admin.py
+++ b/app/models/admin.py
@@ -133,6 +133,8 @@ class AdminDetails(AdminContactInfo):
     note: str | None = None
     role: AdminRoleData | None = None
     permission_overrides: RoleLimits | None = None
+    # None means no per-admin narrowing; a list restricts this admin further.
+    allowed_group_ids: list[int] | None = None
 
     @property
     def is_owner(self) -> bool:
@@ -170,6 +172,16 @@ class AdminModify(BaseModel):
     notification_enable: UserNotificationEnable | None = None
     role_id: int | None = None
     permission_overrides: RoleLimits | None = None
+    # Sending null clears the restriction; omitting the field leaves it
+    # alone. update_admin tells those apart via model_fields_set.
+    allowed_group_ids: list[int] | None = None
+
+    @field_validator("allowed_group_ids")
+    @classmethod
+    def validate_allowed_group_ids(cls, value: list[int] | None) -> list[int] | None:
+        if value is None:
+            return None
+        return list(dict.fromkeys(value))
 
     @field_validator("discord_webhook")
     @classmethod

--- a/app/operation/__init__.py
+++ b/app/operation/__init__.py
@@ -24,7 +24,7 @@ from app.db.models import Admin as DBAdmin, ClientTemplate, CoreConfig, Group, N
 from app.models.admin import AdminDetails
 from app.models.group import BulkGroup
 from app.models.user import UserCreate, UserModify
-from app.operation.permissions import get_scope_admin_id
+from app.operation.permissions import get_allowed_group_ids, get_scope_admin_id
 from app.utils.helpers import ensure_datetime_timezone
 from app.utils.jwt import get_subscription_payload
 
@@ -227,7 +227,22 @@ class BaseOperation:
             await self.raise_error("Group not found", 404)
         return db_group
 
-    async def validate_all_groups(self, db, model: UserCreate | UserModify | UserTemplate | BulkGroup) -> list[Group]:
+    async def validate_all_groups(
+        self,
+        db,
+        model: UserCreate | UserModify | UserTemplate | BulkGroup,
+        admin: AdminDetails | None = None,
+        exempt_group_ids: set[int] | None = None,
+    ) -> list[Group]:
+        """Resolve requested group ids, refusing any the admin may not use.
+
+        `admin` is optional because some callers resolve groups only in order to
+        display them; the access check applies wherever an acting admin is given.
+
+        `exempt_group_ids` are groups already present on the record being
+        edited. They pass even when the admin could not grant them, so that an
+        unrelated edit is not blocked by state the admin never chose.
+        """
         requested_group_ids: list[int] = []
         if model.group_ids:
             requested_group_ids.extend(model.group_ids)
@@ -244,6 +259,16 @@ class BaseOperation:
         missing_ids = [group_id for group_id in unique_ids if group_id not in groups_by_id]
         if missing_ids:
             await self.raise_error("Group not found", 404)
+
+        # The same allowance the group listing is filtered by, so what an admin
+        # can be offered and what they can actually assign cannot drift apart.
+        if admin is not None:
+            allowed_group_ids = get_allowed_group_ids(admin)
+            if allowed_group_ids is not None:
+                allowed = set(allowed_group_ids) | set(exempt_group_ids or ())
+                forbidden = sorted(groups_by_id[gid].name for gid in unique_ids if gid not in allowed)
+                if forbidden:
+                    await self.raise_error(f"You are not allowed to use these groups: {', '.join(forbidden)}", 403)
 
         # Preserve the requested order and duplicate semantics.
         return [groups_by_id[group_id] for group_id in requested_group_ids]

--- a/app/operation/permissions.py
+++ b/app/operation/permissions.py
@@ -132,10 +132,17 @@ def get_effective_limits(admin: AdminDetails) -> RoleLimits:
 
 
 def get_allowed_group_ids(admin: AdminDetails) -> list[int] | None:
-    """None means all groups allowed (owner or no restriction)."""
-    if admin.is_owner or admin.role is None:
+    """None means all groups allowed (owner or no restriction).
+
+    Combines the role's allowance with the admin's own. Intersecting rather
+    than replacing means a per-admin list can only narrow what the role
+    grants, so the role stays an upper bound on what its admins can reach.
+    """
+    if admin.is_owner:
         return None
-    return admin.role.access.allowed_group_ids
+
+    role_allowed = admin.role.access.allowed_group_ids if admin.role is not None else None
+    return _intersect_ids(getattr(admin, "allowed_group_ids", None), role_allowed)
 
 
 def get_allowed_template_ids(admin: AdminDetails) -> list[int] | None:

--- a/app/operation/user.py
+++ b/app/operation/user.py
@@ -672,7 +672,7 @@ class UserOperation(BaseOperation):
         if new_user.next_plan is not None and new_user.next_plan.user_template_id is not None:
             await self.get_validated_user_template(db, new_user.next_plan.user_template_id)
 
-        all_groups = await self.validate_all_groups(db, new_user)
+        all_groups = await self.validate_all_groups(db, new_user, admin)
         db_admin = await get_admin(db, admin.username, load_users=False, load_usage_logs=False)
         # peer IPs are never taken from input; the subnet pool assigns them at creation
         new_user.proxy_settings.wireguard.peer_ips = []
@@ -794,7 +794,9 @@ class UserOperation(BaseOperation):
 
         validated_groups = None
         if modified_user.group_ids is not None:
-            validated_groups = await self.validate_all_groups(db, modified_user)
+            validated_groups = await self.validate_all_groups(
+                db, modified_user, admin, exempt_group_ids={group.id for group in db_user.groups}
+            )
 
         if modified_user.next_plan is not None and modified_user.next_plan.user_template_id is not None:
             await self.get_validated_user_template(db, modified_user.next_plan.user_template_id)
@@ -1775,7 +1777,7 @@ class UserOperation(BaseOperation):
 
         groups: list = []
         if users_to_create:
-            groups = await self.validate_all_groups(db, users_to_create[0])
+            groups = await self.validate_all_groups(db, users_to_create[0], admin)
 
         db_admin = await get_admin(db, admin.username, load_users=False, load_usage_logs=False)
         try:

--- a/dashboard/public/statics/locales/en.json
+++ b/dashboard/public/statics/locales/en.json
@@ -3586,5 +3586,12 @@
     "updateCommandLabel": "Connect via SSH and run:",
     "closeBanner": "Close update notification",
     "needsUpdate": "Needs update"
-  }
+  },
+  "admins.groupAccess.title": "Inbound access",
+  "admins.groupAccess.all": "All",
+  "admins.groupAccess.description": "Choose which groups this admin may assign. Their users can only use the inbounds those groups contain.",
+  "admins.groupAccess.allowAll": "Access to all inbounds",
+  "admins.groupAccess.selectAll": "Select all groups",
+  "admins.groupAccess.noneSelected": "With no group selected, this admin's users get no inbounds at all.",
+  "admins.groupAccess.inboundCount": "{{count}} inbounds"
 }

--- a/dashboard/public/statics/locales/fa.json
+++ b/dashboard/public/statics/locales/fa.json
@@ -3559,5 +3559,12 @@
     "updateCommandLabel": "از طریق SSH متصل شوید و اجرا کنید:",
     "closeBanner": "بستن اعلان به‌روزرسانی",
     "needsUpdate": "نیاز به به‌روزرسانی"
-  }
+  },
+  "admins.groupAccess.title": "دسترسی اینباند",
+  "admins.groupAccess.all": "همه",
+  "admins.groupAccess.description": "مشخص کنید این مدیر مجاز به استفاده از کدام گروه‌هاست. کاربرانی که می‌سازد فقط به اینباندهای همان گروه‌ها دسترسی خواهند داشت.",
+  "admins.groupAccess.allowAll": "دسترسی به همه‌ی اینباندها",
+  "admins.groupAccess.selectAll": "انتخاب همه‌ی گروه‌ها",
+  "admins.groupAccess.noneSelected": "با انتخاب نشدن هیچ گروهی، کاربران این مدیر به هیچ اینباندی دسترسی نخواهند داشت.",
+  "admins.groupAccess.inboundCount": "{{count}} اینباند"
 }

--- a/dashboard/public/statics/locales/ru.json
+++ b/dashboard/public/statics/locales/ru.json
@@ -3543,5 +3543,12 @@
     "updateCommandLabel": "Выполните через SSH:",
     "closeBanner": "Закрыть уведомление об обновлении",
     "needsUpdate": "Требуется обновление"
-  }
+  },
+  "admins.groupAccess.title": "Inbound access",
+  "admins.groupAccess.all": "All",
+  "admins.groupAccess.description": "Choose which groups this admin may assign. Their users can only use the inbounds those groups contain.",
+  "admins.groupAccess.allowAll": "Access to all inbounds",
+  "admins.groupAccess.selectAll": "Select all groups",
+  "admins.groupAccess.noneSelected": "With no group selected, this admin's users get no inbounds at all.",
+  "admins.groupAccess.inboundCount": "{{count}} inbounds"
 }

--- a/dashboard/public/statics/locales/zh.json
+++ b/dashboard/public/statics/locales/zh.json
@@ -3598,5 +3598,12 @@
     "updateCommandLabel": "通过 SSH 连接并运行:",
     "closeBanner": "关闭更新通知",
     "needsUpdate": "需要更新"
-  }
+  },
+  "admins.groupAccess.title": "Inbound access",
+  "admins.groupAccess.all": "All",
+  "admins.groupAccess.description": "Choose which groups this admin may assign. Their users can only use the inbounds those groups contain.",
+  "admins.groupAccess.allowAll": "Access to all inbounds",
+  "admins.groupAccess.selectAll": "Select all groups",
+  "admins.groupAccess.noneSelected": "With no group selected, this admin's users get no inbounds at all.",
+  "admins.groupAccess.inboundCount": "{{count}} inbounds"
 }

--- a/dashboard/src/features/admins/dialogs/admin-modal.tsx
+++ b/dashboard/src/features/admins/dialogs/admin-modal.tsx
@@ -14,14 +14,14 @@ import { Textarea } from '@/components/ui/textarea'
 import { CustomVariablesPopover, normalizeCustomVariableKey, VariablesPopover } from '@/components/ui/variables-popover'
 import { useAdmin } from '@/hooks/use-admin'
 import useDynamicErrorHandler from '@/hooks/use-dynamic-errors.ts'
-import { useCreateAdmin, useGetRolesSimple, useModifyAdminById } from '@/service/api'
+import { useCreateAdmin, useGetAllGroups, useGetRolesSimple, useModifyAdminById } from '@/service/api'
 import type { RoleLimits } from '@/service/api'
 import { builtInVariableKeys, normalizeCustomVariablesForPayload } from '@/features/subscriptions/components/subscription-settings-schema'
 import { upsertAdminInAdminsCache } from '@/utils/adminsCache'
 import { removeAuthToken } from '@/utils/authStorage'
 import { bytesToFormGigabytes, formatBytes, gbToBytes } from '@/utils/formatByte'
 import { useQueryClient } from '@tanstack/react-query'
-import { Bell, IdCard, Pencil, Plus, Sliders, Trash2, UserCog } from 'lucide-react'
+import { Bell, IdCard, Layers, Pencil, Plus, Sliders, Trash2, UserCog } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { UseFormReturn, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -132,6 +132,23 @@ export default function AdminModal({ isDialogOpen, onOpenChange, editingAdminId,
     [watchedPermissionOverrides],
   )
 
+  // Every group with the inbounds it grants, so the choice is made in terms of
+  // what it actually hands out rather than a bare group name.
+  const { data: groupsData, isLoading: groupsLoading } = useGetAllGroups({ limit: 500 }, { query: { enabled: isDialogOpen } })
+  const allGroups = useMemo(() => groupsData?.groups ?? [], [groupsData])
+
+  const watchedRestrictGroups = useWatch({ control: form.control, name: 'restrict_groups' })
+  const watchedAllowedGroupIds = useWatch({ control: form.control, name: 'allowed_group_ids' })
+  const selectedGroupIds = useMemo(() => new Set(watchedAllowedGroupIds ?? []), [watchedAllowedGroupIds])
+  const allGroupsSelected = allGroups.length > 0 && allGroups.every(group => selectedGroupIds.has(group.id))
+
+  const toggleGroup = (groupId: number, checked: boolean) => {
+    const current = new Set(form.getValues('allowed_group_ids') ?? [])
+    if (checked) current.add(groupId)
+    else current.delete(groupId)
+    form.setValue('allowed_group_ids', Array.from(current), { shouldDirty: true })
+  }
+
   const handleAccordionChange = (value: string) => {
     setOpenSection(prev => (prev === value ? undefined : value))
   }
@@ -192,6 +209,8 @@ export default function AdminModal({ isDialogOpen, onOpenChange, editingAdminId,
         notification_enable: values.notification_enable || null,
         role_id: values.role_id,
         permission_overrides: normalizePermissionOverrides(values.permission_overrides),
+        // null lifts the restriction; a list replaces it.
+        allowed_group_ids: values.restrict_groups ? (values.allowed_group_ids ?? []) : null,
       }
       if (editingAdmin && editingAdminId != null) {
         const updatedAdmin = await modifyAdminMutation.mutateAsync({
@@ -235,6 +254,8 @@ export default function AdminModal({ isDialogOpen, onOpenChange, editingAdminId,
           notification_enable: values.notification_enable || null,
           role_id: values.role_id,
           permission_overrides: normalizePermissionOverrides(values.permission_overrides),
+        // null lifts the restriction; a list replaces it.
+        allowed_group_ids: values.restrict_groups ? (values.allowed_group_ids ?? []) : null,
         }
         const createdAdmin = await addAdminMutation.mutateAsync({
           data: createData,
@@ -266,6 +287,7 @@ export default function AdminModal({ isDialogOpen, onOpenChange, editingAdminId,
         'custom_variables',
         'note',
         'permission_overrides',
+        'allowed_group_ids',
       ]
       handleError({ error, fields, form, contextKey: 'admins' })
     }
@@ -710,6 +732,88 @@ export default function AdminModal({ isDialogOpen, onOpenChange, editingAdminId,
                         )}
                       />
                     </div>
+                  </AccordionContent>
+                </AccordionItem>
+
+                <AccordionItem className="rounded-md border px-4 [&_[data-state=closed]]:no-underline [&_[data-state=open]]:no-underline" value="groups">
+                  <AccordionTrigger>
+                    <div className="flex items-center gap-2">
+                      <Layers className="h-4 w-4" />
+                      <span>{t('admins.groupAccess.title', { defaultValue: 'Inbound access' })}</span>
+                      <span className="text-muted-foreground text-xs">
+                        {watchedRestrictGroups ? `${selectedGroupIds.size}/${allGroups.length}` : t('admins.groupAccess.all', { defaultValue: 'All' })}
+                      </span>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="px-1 pt-1">
+                    <p className="text-muted-foreground mb-2 px-1 text-xs">
+                      {t('admins.groupAccess.description', {
+                        defaultValue: 'Choose which groups this admin may assign. Their users can only use the inbounds those groups contain.',
+                      })}
+                    </p>
+
+                    <div className="bg-muted/30 flex items-center justify-between gap-3 rounded-md px-3 py-2">
+                      <span className="text-muted-foreground text-xs">{t('admins.groupAccess.allowAll', { defaultValue: 'Access to all inbounds' })}</span>
+                      <Switch
+                        checked={!watchedRestrictGroups}
+                        onCheckedChange={checked => {
+                          form.setValue('restrict_groups', !checked, { shouldDirty: true })
+                        }}
+                        className="shrink-0"
+                      />
+                    </div>
+
+                    {watchedRestrictGroups && (
+                      <>
+                        <div className="bg-muted/30 mt-2 flex items-center justify-between gap-3 rounded-md px-3 py-2">
+                          <span className="text-muted-foreground text-xs">{t('admins.groupAccess.selectAll', { defaultValue: 'Select all groups' })}</span>
+                          <Switch
+                            checked={allGroupsSelected}
+                            disabled={allGroups.length === 0}
+                            onCheckedChange={checked => {
+                              form.setValue('allowed_group_ids', checked ? allGroups.map(group => group.id) : [], { shouldDirty: true })
+                            }}
+                            className="shrink-0"
+                          />
+                        </div>
+
+                        {selectedGroupIds.size === 0 && !groupsLoading && (
+                          <p className="text-destructive mt-2 px-1 text-xs">
+                            {t('admins.groupAccess.noneSelected', {
+                              defaultValue: 'With no group selected, this admin\'s users get no inbounds at all.',
+                            })}
+                          </p>
+                        )}
+
+                        <div className="mt-2 grid grid-cols-1 gap-1.5 sm:grid-cols-2">
+                          {groupsLoading ? (
+                            <p className="text-muted-foreground px-2 py-1.5 text-xs">{t('loading', { defaultValue: 'Loading...' })}</p>
+                          ) : (
+                            allGroups.map(group => {
+                              const inboundTags = group.inbound_tags ?? []
+                              const checked = selectedGroupIds.has(group.id)
+                              return (
+                                <label
+                                  key={group.id}
+                                  className={`hover:bg-muted/40 flex cursor-pointer items-start gap-x-2 rounded-md border px-2.5 py-2 transition-colors ${checked ? 'border-primary/40 bg-primary/5' : ''}`}
+                                >
+                                  <Checkbox checked={checked} onCheckedChange={value => toggleGroup(group.id, value === true)} className="mt-0.5 h-4 w-4 shrink-0" />
+                                  <span className="min-w-0 flex-1">
+                                    <span className="flex items-center gap-1.5">
+                                      <span className="truncate text-xs font-medium">{group.name}</span>
+                                      <span className="text-muted-foreground shrink-0 text-[10px]">
+                                        {t('admins.groupAccess.inboundCount', { count: inboundTags.length, defaultValue: '{{count}} inbounds' })}
+                                      </span>
+                                    </span>
+                                    {inboundTags.length > 0 && <span className="text-muted-foreground mt-0.5 block truncate text-[10px]" dir="ltr">{inboundTags.join(', ')}</span>}
+                                  </span>
+                                </label>
+                              )
+                            })
+                          )}
+                        </div>
+                      </>
+                    )}
                   </AccordionContent>
                 </AccordionItem>
 

--- a/dashboard/src/features/admins/forms/admin-form.ts
+++ b/dashboard/src/features/admins/forms/admin-form.ts
@@ -74,6 +74,10 @@ export const adminFormSchema = z
         subscription_revoked: z.boolean().optional(),
       })
       .optional(),
+    // null on the wire means unrestricted; the form keeps the two apart with a
+    // switch so that clearing every checkbox stays distinct from "all groups".
+    restrict_groups: z.boolean().optional(),
+    allowed_group_ids: z.array(z.number()).optional(),
     permission_overrides: z
       .object({
         max_users: z.union([z.literal('').transform(() => null), z.null(), z.coerce.number()]).optional(),
@@ -162,5 +166,7 @@ export const adminFormDefaultValues: Partial<AdminFormValuesInput> = {
     data_reset_by_next: true,
     subscription_revoked: true,
   },
+  restrict_groups: false,
+  allowed_group_ids: [],
   permission_overrides: adminPermissionOverridesDefaultValues,
 }

--- a/dashboard/src/pages/_dashboard.admins.tsx
+++ b/dashboard/src/pages/_dashboard.admins.tsx
@@ -153,6 +153,8 @@ export default function AdminsPage() {
       custom_variables: admin.custom_variables || [],
       note: admin.note || '',
       password: undefined,
+      restrict_groups: Array.isArray(admin.allowed_group_ids),
+      allowed_group_ids: admin.allowed_group_ids ?? [],
       permission_overrides: {
         ...adminPermissionOverridesDefaultValues,
         ...(admin.permission_overrides

--- a/dashboard/src/service/api/index.ts
+++ b/dashboard/src/service/api/index.ts
@@ -3702,6 +3702,8 @@ export type AdminModifyTelegramId = number | null
 
 export type AdminModifyPassword = string | null
 
+export type AdminModifyAllowedGroupIds = number[] | null
+
 export interface AdminModify {
   password?: AdminModifyPassword
   telegram_id?: AdminModifyTelegramId
@@ -3717,6 +3719,7 @@ export interface AdminModify {
   notification_enable?: AdminModifyNotificationEnable
   role_id?: AdminModifyRoleId
   permission_overrides?: AdminModifyPermissionOverrides
+  allowed_group_ids?: AdminModifyAllowedGroupIds
 }
 
 export type AdminDetailsPermissionOverrides = RoleLimits | null
@@ -3748,6 +3751,8 @@ export type AdminDetailsId = number | null
 /**
  * Complete admin model with all fields for database representation and API responses.
  */
+export type AdminDetailsAllowedGroupIds = number[] | null
+
 export interface AdminDetails {
   id?: AdminDetailsId
   username: string
@@ -3769,6 +3774,7 @@ export interface AdminDetails {
   permission_overrides?: AdminDetailsPermissionOverrides
   readonly is_disabled: boolean
   readonly is_limited: boolean
+  allowed_group_ids?: AdminDetailsAllowedGroupIds
 }
 
 export type AdminCreatePermissionOverrides = RoleLimits | null
@@ -3798,6 +3804,8 @@ export type AdminCreateTelegramId = number | null
 /**
  * Model for creating new admin accounts requiring username and password.
  */
+export type AdminCreateAllowedGroupIds = number[] | null
+
 export interface AdminCreate {
   password: string
   telegram_id?: AdminCreateTelegramId
@@ -3814,6 +3822,7 @@ export interface AdminCreate {
   role_id: number
   permission_overrides?: AdminCreatePermissionOverrides
   username: string
+  allowed_group_ids?: AdminCreateAllowedGroupIds
 }
 
 export type AdminContactInfoNotificationEnable = UserNotificationEnable | null


### PR DESCRIPTION
> Builds on #754 — the second commit here is that fix. If #754 is merged first, this diff reduces to the feature commit alone.

### What

`allowed_group_ids` currently lives on the **role**, so two admins sharing a role necessarily share the same group allowance. Giving one reseller access to a different set of groups than another means creating a role per reseller, and those roles then differ in nothing but that list.

This adds the same allowance **per admin**, editable from an "Inbound access" section in the admin dialog.

### How it composes with the role

It is folded into `get_allowed_group_ids` rather than run as a mechanism beside the role's:

```python
def get_allowed_group_ids(admin: AdminDetails) -> list[int] | None:
    if admin.is_owner:
        return None
    role_allowed = admin.role.access.allowed_group_ids if admin.role is not None else None
    return _intersect_ids(getattr(admin, "allowed_group_ids", None), role_allowed)
```

So everything that already respects the allowance picks this up with no further change — the group listing, the single fetch, the bulk operations, and the check on user create/modify from #754.

The two **intersect**: a per-admin list can narrow what the role grants but never widen it, so a role remains an upper bound on what its admins can reach.

### Backwards compatibility

`null` means no per-admin narrowing, which is what every existing admin gets after the migration, so behaviour is unchanged until the field is deliberately set. The migration adds one nullable column and nothing else.

Because `null` is meaningful here — it clears the restriction — `update_admin` goes by `model_fields_set` rather than the `is not None` test the neighbouring fields use. Without that an allowance could be set but never cleared:

```python
if "allowed_group_ids" in modified_admin.model_fields_set:
    db_admin.allowed_group_ids = modified_admin.allowed_group_ids
```

### UI

A new accordion section in the admin dialog, following the notification-filter section beside it — same count badge, same toggle-all row. A switch chooses between "access to all inbounds" (`null`) and a selected list.

Each group is shown with the inbounds it grants, since granting a group is really granting its inbounds and that is the decision being made. Selecting nothing is allowed but called out, because it leaves that admin's users with no inbounds.

The generated API client is included, hand-trimmed to only the three added fields — re-running the generator reorders ~290 unrelated lines, which seemed unhelpful to put in front of a reviewer. Happy to replace it with the full generator output if you would rather have that.

### Testing

Verified against a running panel:

- an admin with no per-admin allowance behaves exactly as before
- setting one filters their group listing, and the value round-trips through the API
- assigning a group outside the allowance over the API → `403`, naming the group
- a mix of allowed and forbidden → `403`
- an allowed group → `201`
- users created earlier resolve only the permitted groups' inbounds
- owners are never restricted
- clearing it with `null` restores the previous state exactly, nothing having been destroyed
- an unrelated edit to the admin leaves the allowance intact

Migration applies and reverses cleanly on SQLite, and `alembic check` reports no drift from the models. The existing test suite passes (501 passed, 2 skipped), and the dashboard builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Administrators can now be granted access to all groups or restricted to selected groups.
  - Admin creation and editing screens support selecting permitted groups and display group access details.
  - Group restrictions are enforced when creating, updating, or bulk-creating users.
  - Owners and administrators without role-based limits retain unrestricted access.

- **Localization**
  - Added translations for group-based administrator access controls in English, Persian, Russian, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->