### PR TITLE
ops(docker): rotate panel container logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,11 @@ services:
   pasarguard:
     image: pasarguard/panel:latest
     restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: "25m"
+        max-file: "4"
     env_file: .env
     network_mode: host
     volumes:


### PR DESCRIPTION
## Summary

- bound the panel container's Docker JSON logs to four 25 MB files
- prevent unbounded log growth from exhausting disk on busy installations

Closes #779

## Validation

- parsed `docker-compose.yml` with PyYAML and asserted the resulting logging configuration
- `git diff --check`
- production canary with the same settings: panel returned healthy after a controlled single-service recreation and approximately 2 GB of disk was recovered

## Operational note

The limits take effect when the panel container is recreated. Operators that need the existing Docker JSON log should archive it before recreation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application log management by limiting log files to 25 MB and retaining up to four files.
  * Helps prevent excessive disk usage from accumulated logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->