### PR TITLE
perf(api): collapse single-user read round trips

### DIFF
--- a/app/db/crud/admin.py
+++ b/app/db/crud/admin.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from sqlalchemy import and_, case, delete, func, not_, select, update
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.exc import DetachedInstanceError
 
 from app.db.crud.general import (
@@ -149,7 +149,7 @@ async def get_admin(
 ) -> Admin:
     stmt = select(Admin).where(Admin.username == username)
     if load_role:
-        stmt = stmt.options(selectinload(Admin.role))
+        stmt = stmt.options(joinedload(Admin.role))
     admin = (await db.execute(stmt)).unique().scalar_one_or_none()
     if admin:
         await _load_admin_non_role_attrs(admin, load_users=load_users, load_usage_logs=load_usage_logs)
@@ -258,7 +258,7 @@ async def get_admin_by_id(
 ) -> Admin:
     stmt = select(Admin).where(Admin.id == id)
     if load_role:
-        stmt = stmt.options(selectinload(Admin.role))
+        stmt = stmt.options(joinedload(Admin.role))
     admin = (await db.execute(stmt)).unique().scalar_one_or_none()
     if admin:
         await _load_admin_non_role_attrs(admin, load_users=load_users, load_usage_logs=load_usage_logs)

--- a/app/db/crud/user.py
+++ b/app/db/crud/user.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from sqlalchemy import and_, case, delete, desc, func, literal, not_, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import joinedload, selectinload, with_expression
 from sqlalchemy.sql import Select
 from sqlalchemy.sql.functions import coalesce
 
@@ -120,7 +120,7 @@ def _build_user_select_stmt(
             .correlate(User)
             .scalar_subquery()
         )
-        stmt = stmt.add_columns(reset_traffic.label("_reseted_usage"))
+        stmt = stmt.options(with_expression(User._reseted_usage_query, reset_traffic))
     return stmt
 
 
@@ -203,15 +203,7 @@ async def get_user(
     if admin_id is not None:
         stmt = stmt.where(User.admin_id == admin_id)
 
-    result = (await db.execute(stmt)).unique()
-    if load_lifetime_used_traffic:
-        row = result.one_or_none()
-        if row is None:
-            return None
-        user, reseted_usage = row
-        user.__dict__["_reseted_usage_override"] = int(reseted_usage or 0)
-        return user
-    return result.scalar_one_or_none()
+    return (await db.execute(stmt)).unique().scalar_one_or_none()
 
 
 async def get_user_by_id(
@@ -251,15 +243,7 @@ async def get_user_by_id(
     if admin_id is not None:
         stmt = stmt.where(User.admin_id == admin_id)
 
-    result = (await db.execute(stmt)).unique()
-    if load_lifetime_used_traffic:
-        row = result.one_or_none()
-        if row is None:
-            return None
-        user, reseted_usage = row
-        user.__dict__["_reseted_usage_override"] = int(reseted_usage or 0)
-        return user
-    return result.scalar_one_or_none()
+    return (await db.execute(stmt)).unique().scalar_one_or_none()
 
 
 async def get_user_lifetime_used_traffic(db: AsyncSession, user_id: int) -> int:

--- a/app/db/crud/user.py
+++ b/app/db/crud/user.py
@@ -94,6 +94,8 @@ def _build_user_select_stmt(
     load_next_plan: bool = True,
     load_usage_logs: bool = True,
     load_groups: bool = True,
+    join_groups: bool = False,
+    load_lifetime_used_traffic: bool = False,
 ) -> Select:
     """Build a user select statement with eager-load options."""
     stmt = select(User)
@@ -108,9 +110,17 @@ def _build_user_select_stmt(
     if load_usage_logs:
         options.append(selectinload(User.usage_logs))
     if load_groups:
-        options.append(selectinload(User.groups))
+        options.append(joinedload(User.groups) if join_groups else selectinload(User.groups))
     if options:
         stmt = stmt.options(*options)
+    if load_lifetime_used_traffic:
+        reset_traffic = (
+            select(func.coalesce(func.sum(UserUsageResetLogs.used_traffic_at_reset), 0))
+            .where(UserUsageResetLogs.user_id == User.id)
+            .correlate(User)
+            .scalar_subquery()
+        )
+        stmt = stmt.add_columns(reset_traffic.label("_reseted_usage"))
     return stmt
 
 
@@ -165,6 +175,8 @@ async def get_user(
     load_next_plan: bool = True,
     load_usage_logs: bool = True,
     load_groups: bool = True,
+    join_groups: bool = False,
+    load_lifetime_used_traffic: bool = False,
     admin_id: int | None = None,
 ) -> User | None:
     """
@@ -184,12 +196,22 @@ async def get_user(
         load_next_plan=load_next_plan,
         load_usage_logs=load_usage_logs,
         load_groups=load_groups,
+        join_groups=join_groups,
+        load_lifetime_used_traffic=load_lifetime_used_traffic,
     ).where(User.username == username)
 
     if admin_id is not None:
         stmt = stmt.where(User.admin_id == admin_id)
 
-    return (await db.execute(stmt)).unique().scalar_one_or_none()
+    result = (await db.execute(stmt)).unique()
+    if load_lifetime_used_traffic:
+        row = result.one_or_none()
+        if row is None:
+            return None
+        user, reseted_usage = row
+        user.__dict__["_reseted_usage_override"] = int(reseted_usage or 0)
+        return user
+    return result.scalar_one_or_none()
 
 
 async def get_user_by_id(
@@ -201,6 +223,8 @@ async def get_user_by_id(
     load_next_plan: bool = True,
     load_usage_logs: bool = True,
     load_groups: bool = True,
+    join_groups: bool = False,
+    load_lifetime_used_traffic: bool = False,
     admin_id: int | None = None,
 ) -> User | None:
     """
@@ -220,12 +244,22 @@ async def get_user_by_id(
         load_next_plan=load_next_plan,
         load_usage_logs=load_usage_logs,
         load_groups=load_groups,
+        join_groups=join_groups,
+        load_lifetime_used_traffic=load_lifetime_used_traffic,
     ).where(User.id == user_id)
 
     if admin_id is not None:
         stmt = stmt.where(User.admin_id == admin_id)
 
-    return (await db.execute(stmt)).unique().scalar_one_or_none()
+    result = (await db.execute(stmt)).unique()
+    if load_lifetime_used_traffic:
+        row = result.one_or_none()
+        if row is None:
+            return None
+        user, reseted_usage = row
+        user.__dict__["_reseted_usage_override"] = int(reseted_usage or 0)
+        return user
+    return result.scalar_one_or_none()
 
 
 async def get_user_lifetime_used_traffic(db: AsyncSession, user_id: int) -> int:

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -25,7 +25,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import async_object_session
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, query_expression, relationship
 from sqlalchemy.sql.expression import select, text
 
 from app.db.base import Base
@@ -130,8 +130,6 @@ class Admin(Base, CreatedAtUTCMixin):
 
     @hybrid_property
     def reseted_usage(self) -> int:
-        if "_reseted_usage_override" in self.__dict__:
-            return int(self.__dict__["_reseted_usage_override"])
         return int(sum([log.used_traffic_at_reset for log in self.usage_logs]))
 
     @reseted_usage.expression
@@ -239,6 +237,7 @@ class User(Base, CreatedAtUTCMixin):
     hwid_limit: Mapped[int | None] = mapped_column(BigInteger, default=None)
     edit_at: Mapped[dt | None] = mapped_column(DateTime(timezone=True), default=None)
     last_status_change: Mapped[dt | None] = mapped_column(DateTime(timezone=True), default=None)
+    _reseted_usage_query: Mapped[int | None] = query_expression(repr=False)
 
     @hybrid_property
     def expire(self) -> dt | None:
@@ -262,8 +261,8 @@ class User(Base, CreatedAtUTCMixin):
 
     @hybrid_property
     def reseted_usage(self) -> int:
-        if "_reseted_usage_override" in self.__dict__:
-            return int(self.__dict__["_reseted_usage_override"])
+        if self._reseted_usage_query is not None:
+            return int(self._reseted_usage_query)
         return int(sum([log.used_traffic_at_reset for log in self.usage_logs]))
 
     @reseted_usage.expression

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -130,6 +130,8 @@ class Admin(Base, CreatedAtUTCMixin):
 
     @hybrid_property
     def reseted_usage(self) -> int:
+        if "_reseted_usage_override" in self.__dict__:
+            return int(self.__dict__["_reseted_usage_override"])
         return int(sum([log.used_traffic_at_reset for log in self.usage_logs]))
 
     @reseted_usage.expression
@@ -260,6 +262,8 @@ class User(Base, CreatedAtUTCMixin):
 
     @hybrid_property
     def reseted_usage(self) -> int:
+        if "_reseted_usage_override" in self.__dict__:
+            return int(self.__dict__["_reseted_usage_override"])
         return int(sum([log.used_traffic_at_reset for log in self.usage_logs]))
 
     @reseted_usage.expression
@@ -272,7 +276,7 @@ class User(Base, CreatedAtUTCMixin):
 
     @property
     def lifetime_used_traffic(self) -> int:
-        return int(sum([log.used_traffic_at_reset for log in self.usage_logs]) + self.used_traffic)
+        return self.reseted_usage + self.used_traffic
 
     @property
     def last_traffic_reset_time(self):

--- a/app/operation/__init__.py
+++ b/app/operation/__init__.py
@@ -168,6 +168,8 @@ class BaseOperation:
         load_next_plan: bool = True,
         load_usage_logs: bool = True,
         load_groups: bool = True,
+        join_groups: bool = False,
+        load_lifetime_used_traffic: bool = False,
         scope_resource: str = "users",
         scope_action: str = "read",
     ) -> User:
@@ -178,6 +180,8 @@ class BaseOperation:
             load_next_plan=load_next_plan,
             load_usage_logs=load_usage_logs,
             load_groups=load_groups,
+            join_groups=join_groups,
+            load_lifetime_used_traffic=load_lifetime_used_traffic,
             admin_id=get_scope_admin_id(admin, scope_resource, scope_action),
         )
         if not db_user:
@@ -194,6 +198,8 @@ class BaseOperation:
         load_next_plan: bool = True,
         load_usage_logs: bool = True,
         load_groups: bool = True,
+        join_groups: bool = False,
+        load_lifetime_used_traffic: bool = False,
         scope_resource: str = "users",
         scope_action: str = "read",
     ) -> User:
@@ -204,6 +210,8 @@ class BaseOperation:
             load_next_plan=load_next_plan,
             load_usage_logs=load_usage_logs,
             load_groups=load_groups,
+            join_groups=join_groups,
+            load_lifetime_used_traffic=load_lifetime_used_traffic,
             admin_id=get_scope_admin_id(admin, scope_resource, scope_action),
         )
         if not db_user:

--- a/app/operation/user.py
+++ b/app/operation/user.py
@@ -1408,11 +1408,25 @@ class UserOperation(BaseOperation):
             DeprecationWarning,
             stacklevel=2,
         )
-        db_user = await self.get_validated_user(db, username, admin)
+        db_user = await self.get_validated_user(
+            db,
+            username,
+            admin,
+            load_usage_logs=False,
+            join_groups=True,
+            load_lifetime_used_traffic=True,
+        )
         return await self.validate_user(db_user)
 
     async def get_user_by_id(self, db: AsyncSession, user_id: int, admin: AdminDetails) -> UserNotificationResponse:
-        db_user = await self.get_validated_user_by_id(db, user_id, admin)
+        db_user = await self.get_validated_user_by_id(
+            db,
+            user_id,
+            admin,
+            load_usage_logs=False,
+            join_groups=True,
+            load_lifetime_used_traffic=True,
+        )
         return await self.validate_user(db_user)
 
     async def get_users(

--- a/tests/api/test_user.py
+++ b/tests/api/test_user.py
@@ -12,19 +12,19 @@ from unittest.mock import AsyncMock, MagicMock
 from urllib.parse import parse_qs, unquote, urlsplit
 
 from fastapi import status
-from sqlalchemy import func, select, update
+from sqlalchemy import event, func, select, update
 
 from app.db.crud.hwid import register_user_hwid
-from app.db.models import NodeUserUsage, User, UserStatus
+from app.db.models import NodeUserUsage, User, UserStatus, UserUsageResetLogs
 from app.models.settings import ConfigFormat, SubRule, Subscription
 from app.models.stats import Period, UserCountMetric, UserCountMetricStat, UserCountMetricStatsList
 from app.models.validators import MAX_ON_HOLD_EXPIRE_DURATION_SECONDS
 from app.operation.subscription import SubscriptionOperation
 from app.utils import jwt as jwt_utils
 from app.utils.crypto import generate_wireguard_keypair, get_wireguard_public_key
-from app.utils.jwt import create_subscription_token, get_secret_key, get_subscription_payload
+from app.utils.jwt import create_admin_token, create_subscription_token, get_secret_key, get_subscription_payload
 from config import usage_settings
-from tests.api import TestSession, client
+from tests.api import TestSession, client, engine
 from tests.api.helpers import (
     auth_headers,
     create_admin,
@@ -93,6 +93,36 @@ def count_user_chart_rows(user_id: int) -> int:
             return result.scalar_one()
 
     return asyncio.run(_count_rows())
+
+
+def test_get_user_uses_two_selects_and_preserves_lifetime_traffic():
+    access_token = asyncio.run(create_admin_token(None, "testadmin"))
+    user = create_user(access_token, username=unique_name("single_read"))
+
+    async def _add_reset_log():
+        async with TestSession() as session:
+            session.add(UserUsageResetLogs(user_id=user["id"], used_traffic_at_reset=12345))
+            await session.commit()
+
+    asyncio.run(_add_reset_log())
+
+    select_count = 0
+
+    def _count_selects(*args):
+        nonlocal select_count
+        statement = args[2]
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_count += 1
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _count_selects)
+    try:
+        response = client.get(f"/api/user/{user['username']}", headers=auth_headers(access_token))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["lifetime_used_traffic"] == 12345
+        assert select_count == 2
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _count_selects)
+        delete_user(access_token, user["username"])
 
 
 def extract_wireguard_config_bodies(response) -> list[str]:

--- a/tests/api/test_user.py
+++ b/tests/api/test_user.py
@@ -15,6 +15,7 @@ from fastapi import status
 from sqlalchemy import event, func, select, update
 
 from app.db.crud.hwid import register_user_hwid
+from app.db.crud.user import get_user as get_db_user
 from app.db.models import NodeUserUsage, User, UserStatus, UserUsageResetLogs
 from app.models.settings import ConfigFormat, SubRule, Subscription
 from app.models.stats import Period, UserCountMetric, UserCountMetricStat, UserCountMetricStatsList
@@ -96,6 +97,7 @@ def count_user_chart_rows(user_id: int) -> int:
 
 
 def test_get_user_uses_two_selects_and_preserves_lifetime_traffic():
+    """The optimized endpoint keeps its two-query budget and response semantics."""
     access_token = asyncio.run(create_admin_token(None, "testadmin"))
     user = create_user(access_token, username=unique_name("single_read"))
 
@@ -122,6 +124,38 @@ def test_get_user_uses_two_selects_and_preserves_lifetime_traffic():
         assert select_count == 2
     finally:
         event.remove(engine.sync_engine, "before_cursor_execute", _count_selects)
+        delete_user(access_token, user["username"])
+
+
+def test_optimized_lifetime_traffic_is_refreshed_in_same_session():
+    """A query-scoped aggregate must not outlive a subsequent ORM refresh."""
+    access_token = asyncio.run(create_admin_token(None, "testadmin"))
+    user = create_user(access_token, username=unique_name("fresh_lifetime"))
+
+    async def _check_refresh():
+        async with TestSession() as session:
+            db_user = await get_db_user(
+                session,
+                user["username"],
+                load_admin=False,
+                load_next_plan=False,
+                load_usage_logs=False,
+                load_groups=False,
+                load_lifetime_used_traffic=True,
+            )
+            assert db_user is not None
+            initial_lifetime_used_traffic = db_user.lifetime_used_traffic
+
+            session.add(UserUsageResetLogs(user_id=user["id"], used_traffic_at_reset=23456))
+            await session.commit()
+            await session.refresh(db_user)
+            await db_user.awaitable_attrs.usage_logs
+
+            assert db_user.lifetime_used_traffic == initial_lifetime_used_traffic + 23456
+
+    try:
+        asyncio.run(_check_refresh())
+    finally:
         delete_user(access_token, user["username"])
 
 


### PR DESCRIPTION
## Summary

- collapse JWT admin + role loading into one query for request authentication
- join groups for the singular user lookup instead of issuing a separate SELECT
- calculate reset traffic with an indexed correlated aggregate instead of loading reset-log objects
- preserve response fields, authorization scope, freshness, subscription URL generation, and existing list-query loading behavior
- add a regression test that asserts the full request uses two SELECTs and preserves lifetime traffic

Closes #781

## Compatibility

- no API contract change
- no cache or stale response window
- no rate limit or client restriction
- no database migration
- list endpoints keep their existing `selectinload` strategy to avoid collection cartesian expansion

## Validation

- `ruff check` on all changed files
- `tests/api/test_user.py`: 83 passed on `dev`
- `tests/api/test_admin.py`: 52 passed on `dev`
- exact 5.2.1 compatibility branch: 132 complete user/admin tests passed

## Production canary

On an anonymized ~25k-user PostgreSQL/TimescaleDB installation, matched 15-request samples under the same ongoing external load improved as follows:

- average: 794 ms -> 484 ms (-39%)
- median: 752 ms -> 440 ms (-41%)
- p95: 947 ms -> 546 ms (-42%)

All responses were HTTP 200; response size and schema hash were identical. No tracebacks, usage-job errors, lock waiters, or accounting interruption were observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user retrieval to preserve lifetime traffic usage after usage resets.
  * User details now include group information and lifetime usage consistently.
  * Admin and user role or group data load more efficiently without changing results.

* **Tests**
  * Added coverage confirming lifetime traffic remains accurate after reset activity.
  * Verified user retrieval completes with an optimized number of database queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->