### PR TITLE
perf(system): collapse dashboard user metrics into one query

### DIFF
--- a/app/db/crud/user.py
+++ b/app/db/crud/user.py
@@ -864,7 +864,11 @@ async def get_users_count_metrics(
     online_window: timedelta,
     admin_id: int | None = None,
 ) -> tuple[dict[str, int], int]:
-    """Return per-status, total, and recent-online user counts in one SELECT."""
+    """Return per-status, total, and recent-online user counts in one SELECT.
+
+    The ``total`` value includes only the requested statuses. Pass every
+    ``UserStatus`` value when a complete user count is required.
+    """
     stmt = _build_user_count_metrics_query(statuses, datetime.now(UTC) - online_window, admin_id)
     row = (await db.execute(stmt)).one()
 

--- a/app/db/crud/user.py
+++ b/app/db/crud/user.py
@@ -827,37 +827,50 @@ async def get_users_count(db: AsyncSession, status: UserStatus = None, admin_id:
     return result.scalar()
 
 
-async def get_users_count_by_status(
-    db: AsyncSession, statuses: list[UserStatus], admin_id: int | None = None
-) -> dict[str, int]:
-    """
-    Gets count of users grouped by status in a single query.
+def _build_user_count_metrics_query(
+    statuses: list[UserStatus], online_since: datetime, admin_id: int | None = None
+) -> Select:
+    """Build one index-aware query for dashboard user counts."""
+    if admin_id is not None:
+        status_columns = [
+            select(func.count(User.id))
+            .where(User.admin_id == admin_id, User.status == status)
+            .scalar_subquery()
+            .label(status.value)
+            for status in statuses
+        ]
+        online_column = (
+            select(func.count(User.id))
+            .where(
+                User.admin_id == admin_id,
+                User.online_at.isnot(None),
+                User.online_at >= online_since,
+            )
+            .scalar_subquery()
+            .label("online")
+        )
+        return select(*status_columns, online_column)
 
-    Args:
-        db (AsyncSession): Database session.
-        statuses (list[UserStatus]): List of statuses to count.
-        admin_id (int, optional): Filter by admin.
-    Returns:
-        dict[str, int]: Dictionary with status counts and total.
-    """
-    stmt = select(User.status, func.count(User.id).label("count"))
+    status_columns = [func.count(case((User.status == status, User.id))).label(status.value) for status in statuses]
+    online_column = func.count(case((and_(User.online_at.isnot(None), User.online_at >= online_since), User.id))).label(
+        "online"
+    )
+    return select(*status_columns, online_column)
 
-    filters = [User.status.in_(statuses)]
-    if admin_id:
-        filters.append(User.admin_id == admin_id)
 
-    stmt = stmt.where(and_(*filters)).group_by(User.status)
+async def get_users_count_metrics(
+    db: AsyncSession,
+    statuses: list[UserStatus],
+    online_window: timedelta,
+    admin_id: int | None = None,
+) -> tuple[dict[str, int], int]:
+    """Return per-status, total, and recent-online user counts in one SELECT."""
+    stmt = _build_user_count_metrics_query(statuses, datetime.now(UTC) - online_window, admin_id)
+    row = (await db.execute(stmt)).one()
 
-    result = await db.execute(stmt)
-    status_counts = {row.status.value: row.count for row in result}
-
-    # Ensure all requested statuses are present with 0 count if missing
-    all_statuses = {status.value: status_counts.get(status.value, 0) for status in statuses}
-
-    # Add total count
-    all_statuses["total"] = sum(all_statuses.values())
-
-    return all_statuses
+    status_counts = {status.value: int(getattr(row, status.value) or 0) for status in statuses}
+    status_counts["total"] = sum(status_counts.values())
+    return status_counts, int(row.online or 0)
 
 
 async def create_user(
@@ -1862,22 +1875,3 @@ async def delete_user_passed_notification_reminders(
 
     stmt = delete(NotificationReminder).where(and_(*conditions))
     await db.execute(stmt)
-
-
-async def count_online_users(db: AsyncSession, time_delta: timedelta, admin_id: int | None = None):
-    """
-    Counts the number of users who have been online within the specified time delta.
-
-    Args:
-        db (AsyncSession): The database session.
-        time_delta (timedelta): The time period to check for online users.
-        admin_id (int, optional): Filter by admin.
-
-    Returns:
-        int: The number of users who have been online within the specified time period.
-    """
-    twenty_four_hours_ago = datetime.now(UTC) - time_delta
-    query = select(func.count(User.id)).where(User.online_at.isnot(None), User.online_at >= twenty_four_hours_ago)
-    if admin_id:
-        query = query.where(User.admin_id == admin_id)
-    return (await db.execute(query)).scalar_one_or_none()

--- a/app/operation/system.py
+++ b/app/operation/system.py
@@ -6,7 +6,7 @@ from app.core.manager import core_manager
 from app.db import AsyncSession
 from app.db.crud.admin import build_admin_details, get_admin
 from app.db.crud.general import get_system_usage
-from app.db.crud.user import count_online_users, get_users_count_by_status
+from app.db.crud.user import get_users_count_metrics
 from app.db.models import UserStatus
 from app.models.admin import AdminDetails
 from app.models.system import InboundSummary, SystemResourceStats, SystemStats, SystemUsersStats
@@ -79,8 +79,7 @@ class SystemOperation(BaseOperation):
         else:
             system = None
 
-        user_counts = await get_users_count_by_status(db, statuses, admin_id)
-        online_users = await count_online_users(db, timedelta(minutes=2), admin_id)
+        user_counts, online_users = await get_users_count_metrics(db, statuses, timedelta(minutes=2), admin_id)
 
         if system is not None:
             uplink = system.uplink

--- a/tests/test_system_user_metrics.py
+++ b/tests/test_system_user_metrics.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import event
 from sqlalchemy.dialects import mysql, postgresql, sqlite
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -20,8 +21,8 @@ STATUSES = [
 ]
 
 
-@pytest.mark.asyncio
-async def test_user_count_metrics_are_scoped_complete_and_use_one_select():
+@pytest_asyncio.fixture
+async def seeded_session():
     engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -69,58 +70,80 @@ async def test_user_count_metrics_are_scoped_complete_and_use_one_select():
                 ]
             )
             await session.flush()
-
-            select_count = 0
-
-            def count_selects(_, __, statement, *args):
-                nonlocal select_count
-                if statement.lstrip().upper().startswith("SELECT"):
-                    select_count += 1
-
-            event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
-            try:
-                global_counts, global_online = await get_users_count_metrics(session, STATUSES, timedelta(minutes=2))
-            finally:
-                event.remove(engine.sync_engine, "before_cursor_execute", count_selects)
-
-            assert select_count == 1
-            assert global_counts == {
-                "active": 1,
-                "disabled": 1,
-                "on_hold": 1,
-                "expired": 1,
-                "limited": 1,
-                "total": 5,
-            }
-            assert global_online == 2
-
-            scoped_counts, scoped_online = await get_users_count_metrics(
-                session, STATUSES, timedelta(minutes=2), admin_id=101
-            )
-            assert scoped_counts == {
-                "active": 1,
-                "disabled": 1,
-                "on_hold": 0,
-                "expired": 1,
-                "limited": 0,
-                "total": 3,
-            }
-            assert scoped_online == 1
-
-            empty_counts, empty_online = await get_users_count_metrics(
-                session, STATUSES, timedelta(minutes=2), admin_id=999
-            )
-            assert empty_counts == {
-                "active": 0,
-                "disabled": 0,
-                "on_hold": 0,
-                "expired": 0,
-                "limited": 0,
-                "total": 0,
-            }
-            assert empty_online == 0
+            yield engine, session
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("admin_id", [None, 101])
+async def test_user_count_metrics_use_one_select(seeded_session, admin_id):
+    engine, session = seeded_session
+    select_count = 0
+
+    def count_selects(_, __, statement, *args):
+        nonlocal select_count
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_count += 1
+
+    event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
+    try:
+        await get_users_count_metrics(session, STATUSES, timedelta(minutes=2), admin_id=admin_id)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", count_selects)
+
+    assert select_count == 1
+
+
+@pytest.mark.asyncio
+async def test_global_user_count_metrics_are_complete(seeded_session):
+    _, session = seeded_session
+
+    counts, online = await get_users_count_metrics(session, STATUSES, timedelta(minutes=2))
+
+    assert counts == {
+        "active": 1,
+        "disabled": 1,
+        "on_hold": 1,
+        "expired": 1,
+        "limited": 1,
+        "total": 5,
+    }
+    assert online == 2
+
+
+@pytest.mark.asyncio
+async def test_user_count_metrics_are_scoped_to_admin(seeded_session):
+    _, session = seeded_session
+
+    counts, online = await get_users_count_metrics(session, STATUSES, timedelta(minutes=2), admin_id=101)
+
+    assert counts == {
+        "active": 1,
+        "disabled": 1,
+        "on_hold": 0,
+        "expired": 1,
+        "limited": 0,
+        "total": 3,
+    }
+    assert online == 1
+
+
+@pytest.mark.asyncio
+async def test_user_count_metrics_are_zero_for_unknown_admin(seeded_session):
+    _, session = seeded_session
+
+    counts, online = await get_users_count_metrics(session, STATUSES, timedelta(minutes=2), admin_id=999)
+
+    assert counts == {
+        "active": 0,
+        "disabled": 0,
+        "on_hold": 0,
+        "expired": 0,
+        "limited": 0,
+        "total": 0,
+    }
+    assert online == 0
 
 
 @pytest.mark.parametrize("dialect", [sqlite.dialect(), postgresql.dialect(), mysql.dialect()])

--- a/tests/test_system_user_metrics.py
+++ b/tests/test_system_user_metrics.py
@@ -1,0 +1,146 @@
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.dialects import mysql, postgresql, sqlite
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.crud.user import _build_user_count_metrics_query, get_users_count_metrics
+from app.db.models import User, UserStatus
+
+STATUSES = [
+    UserStatus.active,
+    UserStatus.disabled,
+    UserStatus.on_hold,
+    UserStatus.expired,
+    UserStatus.limited,
+]
+
+
+@pytest.mark.asyncio
+async def test_user_count_metrics_are_scoped_complete_and_use_one_select():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    now = datetime.now(UTC)
+    prefix = uuid4().hex[:8]
+
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            session.add_all(
+                [
+                    User(
+                        username=f"{prefix}_active",
+                        admin_id=101,
+                        status=UserStatus.active,
+                        online_at=now - timedelta(seconds=30),
+                    ),
+                    User(
+                        username=f"{prefix}_disabled",
+                        admin_id=101,
+                        status=UserStatus.disabled,
+                    ),
+                    User(
+                        username=f"{prefix}_expired",
+                        admin_id=101,
+                        status=UserStatus.expired,
+                        online_at=now - timedelta(minutes=3),
+                    ),
+                    User(
+                        username=f"{prefix}_limited",
+                        admin_id=202,
+                        status=UserStatus.limited,
+                        online_at=now - timedelta(seconds=45),
+                    ),
+                    User(
+                        username=f"{prefix}_on_hold",
+                        admin_id=202,
+                        status=UserStatus.on_hold,
+                    ),
+                ]
+            )
+            await session.flush()
+
+            select_count = 0
+
+            def count_selects(_, __, statement, *args):
+                nonlocal select_count
+                if statement.lstrip().upper().startswith("SELECT"):
+                    select_count += 1
+
+            event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
+            try:
+                global_counts, global_online = await get_users_count_metrics(session, STATUSES, timedelta(minutes=2))
+            finally:
+                event.remove(engine.sync_engine, "before_cursor_execute", count_selects)
+
+            assert select_count == 1
+            assert global_counts == {
+                "active": 1,
+                "disabled": 1,
+                "on_hold": 1,
+                "expired": 1,
+                "limited": 1,
+                "total": 5,
+            }
+            assert global_online == 2
+
+            scoped_counts, scoped_online = await get_users_count_metrics(
+                session, STATUSES, timedelta(minutes=2), admin_id=101
+            )
+            assert scoped_counts == {
+                "active": 1,
+                "disabled": 1,
+                "on_hold": 0,
+                "expired": 1,
+                "limited": 0,
+                "total": 3,
+            }
+            assert scoped_online == 1
+
+            empty_counts, empty_online = await get_users_count_metrics(
+                session, STATUSES, timedelta(minutes=2), admin_id=999
+            )
+            assert empty_counts == {
+                "active": 0,
+                "disabled": 0,
+                "on_hold": 0,
+                "expired": 0,
+                "limited": 0,
+                "total": 0,
+            }
+            assert empty_online == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.parametrize("dialect", [sqlite.dialect(), postgresql.dialect(), mysql.dialect()])
+def test_global_user_count_metrics_query_compiles_for_supported_dialects(dialect):
+    stmt = _build_user_count_metrics_query(STATUSES, datetime(2026, 1, 1, tzinfo=UTC))
+
+    sql = str(stmt.compile(dialect=dialect)).upper()
+
+    assert sql.startswith("SELECT")
+    assert "COUNT(CASE WHEN" in sql
+    assert sql.count("FROM USERS") == 1
+
+
+@pytest.mark.parametrize("dialect", [sqlite.dialect(), postgresql.dialect(), mysql.dialect()])
+def test_scoped_user_count_metrics_query_compiles_to_indexable_counts(dialect):
+    stmt = _build_user_count_metrics_query(STATUSES, datetime(2026, 1, 1, tzinfo=UTC), admin_id=1)
+
+    sql = str(stmt.compile(dialect=dialect)).upper()
+
+    assert sql.startswith("SELECT")
+    assert "COUNT(CASE WHEN" not in sql
+    assert sql.count("SELECT COUNT(") == len(STATUSES) + 1
+    assert sql.count("USERS.ADMIN_ID =") == len(STATUSES) + 1


### PR DESCRIPTION
## Summary

- Collapse dashboard status counts and recent-online count into one database statement.
- Use conditional aggregation for global metrics and index-friendly scalar aggregates for admin-scoped metrics.
- Preserve the existing API response, two-minute online window, and admin visibility rules.
- Add correctness, query-budget, and SQLite/PostgreSQL/MySQL compilation coverage.

Closes #790

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / cleanup
- [ ] Documentation
- [x] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed.
- [x] I checked database migrations when models or schema changed.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

No documentation or migration is needed because the endpoint contract and schema are unchanged.

## Testing

- `.venv\Scripts\python.exe -m ruff check .` — all checks passed
- `.venv\Scripts\python.exe -m pytest -q tests/api/test_system.py tests/test_system_user_metrics.py` — 10 passed
- `.venv\Scripts\python.exe -m pytest -q` — 532 passed, 2 skipped

Directional SQLite benchmark with 500,000 synthetic users and indexes matching the model:

| Scope | Before (2 statements) | After (1 statement) | Change |
| --- | ---: | ---: | ---: |
| Global | 189.471 ms | 100.954 ms | -46.7% |
| Admin-scoped | 0.435 ms | 0.180 ms | -58.7% |

These local synthetic numbers are not a production latency guarantee; they validate the query shape and guard against the scoped conditional-aggregation regression discovered during implementation.

## Screenshots

Not applicable (backend-only change).

## Notes for reviewers

The global and scoped SQL shapes are intentionally different. A single conditional scan was faster globally, but it regressed the scoped path by bypassing the existing composite indexes. Scalar aggregate subqueries keep the scoped request to one round trip while allowing each count to use `(admin_id, status)` or `(admin_id, online_at)`.

Frontend polling changes are intentionally out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - User metrics now include per-status counts, total users, and users active within the last two minutes.
  - Metrics can be filtered to a specific administrative scope.
  - Empty scopes and all supported user statuses are handled consistently.

- **Performance**
  - User metrics are collected through a consolidated query for more efficient system reporting.

- **Tests**
  - Added coverage for global and scoped metrics across supported database systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->