### PR TITLE
fix(admin): allow clearing data limit with null

### DIFF
--- a/app/db/crud/admin.py
+++ b/app/db/crud/admin.py
@@ -190,8 +190,12 @@ async def update_admin(db: AsyncSession, db_admin: Admin, modified_admin: AdminM
     if modified_admin.status is not None and modified_admin.status != db_admin.status:
         db_admin.status = modified_admin.status
         db_admin.last_status_change = datetime.now(UTC)
-    if modified_admin.data_limit is not None:
-        db_admin.data_limit = modified_admin.data_limit if modified_admin.data_limit > 0 else None
+    if "data_limit" in modified_admin.model_fields_set:
+        db_admin.data_limit = (
+            modified_admin.data_limit
+            if modified_admin.data_limit is not None and modified_admin.data_limit > 0
+            else None
+        )
         # Recompute limited/active based on new data_limit — never touch disabled
         if db_admin.status != AdminStatus.disabled:
             should_be_limited = (

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1358,6 +1358,37 @@ def test_admin_data_limit_zero_means_unlimited(access_token):
         delete_admin(access_token, admin["username"])
 
 
+def test_admin_data_limit_null_means_unlimited(access_token):
+    """Explicit data_limit=null clears the limit while an omitted field leaves it unchanged."""
+    admin = create_admin(access_token)
+    try:
+        response = client.put(
+            f"/api/admin/{admin['username']}",
+            json={"data_limit": 1073741824},
+            headers=auth_headers(access_token),
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["data_limit"] == 1073741824
+
+        response = client.put(
+            f"/api/admin/{admin['username']}",
+            json={"note": "keep the existing limit"},
+            headers=auth_headers(access_token),
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["data_limit"] == 1073741824
+
+        response = client.put(
+            f"/api/admin/{admin['username']}",
+            json={"data_limit": None},
+            headers=auth_headers(access_token),
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["data_limit"] is None
+    finally:
+        delete_admin(access_token, admin["username"])
+
+
 def test_admin_status_defaults_to_active(access_token):
     """Newly created admin has status=active."""
     admin = create_admin(access_token)


### PR DESCRIPTION
## Summary

- Distinguish an omitted `data_limit` from an explicit `null` in admin updates.
- Clear the persisted limit when API clients send `{"data_limit": null}` while preserving the existing `0` behavior.
- Add API regression coverage for omitted, zero, and explicit-null updates.

Fixes #802

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed.
- [x] I checked database migrations when models or schema changed.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

```text
python -m pytest tests/api/test_admin.py::test_admin_data_limit_set_and_returned tests/api/test_admin.py::test_admin_data_limit_zero_means_unlimited tests/api/test_admin.py::test_admin_data_limit_null_means_unlimited -q
3 passed

python -m ruff check app/db/crud/admin.py tests/api/test_admin.py
All checks passed!

python -m ruff format --check app/db/crud/admin.py tests/api/test_admin.py
2 files already formatted
```

## Screenshots

Not applicable.

## Notes for reviewers

This uses Pydantic's `model_fields_set` to preserve partial-update semantics: omitting `data_limit` leaves it unchanged, while explicitly sending `null` clears it. No database migration or API schema change is required, and `data_limit: 0` remains supported for backward compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admin data limits can now be explicitly cleared by setting them to null.
  - Omitting the data limit preserves its existing value.
  - Non-positive limits continue to be treated as unlimited.

- **Tests**
  - Added coverage confirming the distinction between omitted and explicitly cleared data limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->