### PR TITLE
fix(dashboard): copy configs on insecure contexts

### DIFF
--- a/dashboard/src/features/subscriptions/dialogs/subscription-modal.tsx
+++ b/dashboard/src/features/subscriptions/dialogs/subscription-modal.tsx
@@ -10,6 +10,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Skeleton } from '@/components/ui/skeleton'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { useClipboard } from '@/hooks/use-clipboard'
 import {
   downloadTextFile,
   encodeSubscriptionContentToBase64,
@@ -50,6 +51,7 @@ const SubscriptionModal: FC<SubscriptionModalProps> = memo(({ open, subscribeUrl
   const isOpen = open ?? subscribeUrl !== null
   const { t } = useTranslation()
   const dir = useDirDetection()
+  const { copy } = useClipboard({ timeout: 1500 })
   const isRTL = dir === 'rtl'
 
   const [configs, setConfigs] = useState<ConfigItem[]>([])
@@ -126,7 +128,8 @@ const SubscriptionModal: FC<SubscriptionModalProps> = memo(({ open, subscribeUrl
       try {
         const preparedContent = prepareSubscriptionContentForCopy(config).content
         const copyContent = mode === 'base64' ? encodeSubscriptionContentToBase64(preparedContent) : preparedContent
-        await navigator.clipboard.writeText(copyContent)
+        const copied = await copy(copyContent)
+        if (!copied) throw new Error('Failed to copy configuration')
         setCopiedConfig({ config, mode })
         toast.success(t('usersTable.copied', { defaultValue: 'Copied' }))
         setTimeout(() => setCopiedConfig(null), 1500)
@@ -134,20 +137,21 @@ const SubscriptionModal: FC<SubscriptionModalProps> = memo(({ open, subscribeUrl
         toast.error(t('copyFailed', { defaultValue: 'Failed to copy' }))
       }
     },
-    [t],
+    [copy, t],
   )
 
   const handleCopyAllConfigs = useCallback(async () => {
     try {
       const content = prepareSubscriptionContentForCopy(configs.map(item => item.config).join('\n')).content
-      await navigator.clipboard.writeText(content)
+      const copied = await copy(content)
+      if (!copied) throw new Error('Failed to copy configurations')
       setAllConfigsCopied(true)
       toast.success(t('usersTable.copied', { defaultValue: 'Copied' }))
       setTimeout(() => setAllConfigsCopied(false), 1500)
     } catch {
       toast.error(t('copyFailed', { defaultValue: 'Failed to copy' }))
     }
-  }, [configs, t])
+  }, [configs, copy, t])
 
   const handleDownloadWireGuard = useCallback(
     (config: string) => {


### PR DESCRIPTION
## Summary

- Route subscription configuration copies through the shared clipboard helper.
- Fall back to the legacy copy path when the Clipboard API is unavailable on insecure HTTP origins.
- Only show the copied state and success toast after the clipboard operation actually succeeds.

Fixes #704

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [ ] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed.
- [x] I checked database migrations when models or schema changed.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

```text
node node_modules/typescript/bin/tsc --noEmit
Passed

node node_modules/prettier/bin/prettier.cjs --check src/features/subscriptions/dialogs/subscription-modal.tsx
Passed

node node_modules/vite/bin/vite.js build
Passed (600 PWA precache entries generated)

git diff --check
Passed
```

ESLint could not start in this checkout because `eslint.config.js` imports `@eslint/js`, which is not present in the installed dependencies. TypeScript and the full production build both passed.

## Screenshots

Not applicable; this changes clipboard behavior without altering the UI.

## Notes for reviewers

The subscription modal bypassed the existing `useClipboard` helper and called `navigator.clipboard.writeText` directly. Browsers restrict that API to secure contexts, so locally hosted panels opened over plain HTTP could generate valid configurations and QR codes while leaving the clipboard empty. Both single-config and Copy All actions now use the existing helper, including its `execCommand` fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copying subscription configurations, including clearer handling when a copy operation fails.
  * Preserved success and error notifications and copied-state feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->