### PR TITLE
feat: allow binding to all interfaces w/o SSL certificate

### DIFF
--- a/config.py
+++ b/config.py
@@ -56,6 +56,7 @@ class ServerSettings(EnvSettings):
     ssl_certfile: str | None = Field(default=None, validation_alias="UVICORN_SSL_CERTFILE")
     ssl_keyfile: str | None = Field(default=None, validation_alias="UVICORN_SSL_KEYFILE")
     ssl_ca_type: str = Field(default="public", validation_alias="UVICORN_SSL_CA_TYPE")
+    dangerously_bypass_ssl: bool = Field(default=False, validation_alias="UVICORN_DANGEROUSLY_BYPASS_SSL")
     workers: int = Field(default=1, validation_alias="UVICORN_WORKERS")
     loop: str = Field(default="auto", validation_alias="UVICORN_LOOP")
     proxy_headers: bool = Field(default=False, validation_alias="UVICORN_PROXY_HEADERS")

--- a/main.py
+++ b/main.py
@@ -116,6 +116,25 @@ if __name__ == "__main__":
             bind_args["host"] = server_settings.host
             bind_args["port"] = server_settings.port
 
+    elif server_settings.dangerously_bypass_ssl:
+        logger.warning(f"""\
+{click.style("IMPORTANT!", blink=True, bold=True, fg="yellow")}
+You've enabled {click.style("UVICORN_DANGEROUSLY_BYPASS_SSL", italic=True, fg="magenta")} while no
+{click.style("UVICORN_SSL_CERTFILE", italic=True, fg="magenta")}/{click.style("UVICORN_SSL_KEYFILE", italic=True, fg="magenta")} are configured. 
+PasarGuard will bind to {click.style(f"{server_settings.host}:{server_settings.port}", bold=True)} over {click.style("plain HTTP", bold=True)}.
+
+Only use this when a trusted reverse proxy (Nginx/Caddy/Traefik) or a separate
+TLS terminating layer in front of the container provides encryption.
+Exposing the panel on a public interface without TLS will transmit
+credentials in cleartext.
+""")
+
+        if server_settings.uds:
+            bind_args["uds"] = server_settings.uds
+        else:
+            bind_args["host"] = server_settings.host
+            bind_args["port"] = server_settings.port
+
     else:
         if server_settings.uds:
             bind_args["uds"] = server_settings.uds


### PR DESCRIPTION
## Summary

Docker/Podman containers with **bridged network** can only publish ports that are bound to `0.0.0.0`. Right now, when PasarGuard runs without `UVICORN_SSL_CERTFILE` / `UVICORN_SSL_KEYFILE`, it restricts binding to `127.0.0.1` only, making panel unreachable from the host when fronted by a TLS terminating reverse proxy like Nginx, Caddy or Traefik.

This adds an opt-in `UVICORN_DANGEROUSLY_BYPASS_SSL` flag that binds to the configured host/port even without certificates. It defaults to `False`, so the current secure behavior is unchanged unless explicitly opted in.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated documentation, translations, or examples if needed.
- [ ] I checked database migrations when models or schema changed.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

Running container with flag set to `True`:
```
Aug 23 15:13:37 fedora pasarguard[1471135]: WARNING:  2026-08-23 10:13:37,882 - Uvicorn-main - IMPORTANT!
Aug 23 15:13:37 fedora pasarguard[1471135]: You've enabled UVICORN_DANGEROUSLY_BYPASS_SSL while no
Aug 23 15:13:37 fedora pasarguard[1471135]: UVICORN_SSL_CERTFILE/UVICORN_SSL_KEYFILE are configured. 
Aug 23 15:13:37 fedora pasarguard[1471135]: PasarGuard will bind to 0.0.0.0:8000 over plain HTTP.
Aug 23 15:13:37 fedora pasarguard[1471135]: 
Aug 23 15:13:37 fedora pasarguard[1471135]: Only use this when a trusted reverse proxy (Nginx/Caddy/Traefik) or a separate
Aug 23 15:13:37 fedora pasarguard[1471135]: TLS terminating layer in front of the container provides encryption.
Aug 23 15:13:37 fedora pasarguard[1471135]: Exposing the panel on a public interface without TLS will transmit
Aug 23 15:13:37 fedora pasarguard[1471135]: credentials in cleartext.
Aug 23 15:13:37 fedora pasarguard[1471135]: 
Aug 23 15:13:45 fedora pasarguard[1471135]: INFO:     2026-08-23 10:13:45,174 - Started server process [1]
Aug 23 15:13:45 fedora pasarguard[1471135]: INFO:     2026-08-23 10:13:45,174 - Waiting for application startup.
Aug 23 15:13:45 fedora pasarguard[1471135]: INFO:     2026-08-23 10:13:45,261 - Node-checker - Starting nodes' cores...
Aug 23 15:13:45 fedora pasarguard[1471135]: WARNING:  2026-08-23 10:13:45,269 - Node-checker - Attention: You have no node, you need to have at least one node
Aug 23 15:13:45 fedora pasarguard[1471135]: INFO:     2026-08-23 10:13:45,270 - App-factory - PasarGuard v5.2.1 (all-in-one)
Aug 23 15:13:45 fedora pasarguard[1471135]: INFO:     2026-08-23 10:13:45,270 - Application startup complete.
Aug 23 15:13:45 fedora pasarguard[1471135]: INFO:     2026-08-23 10:13:45,270 - Uvicorn running on http://0.0.0.0:8000
```

Running container without setting the flag or set to `False`:
```
Aug 23 15:16:32 fedora pasarguard[1475393]: WARNING:  2026-08-23 10:16:32,466 - Uvicorn-main - 
Aug 23 15:16:32 fedora pasarguard[1475393]: IMPORTANT!
Aug 23 15:16:32 fedora pasarguard[1475393]: You're running PasarGuard without specifying UVICORN_SSL_CERTFILE and UVICORN_SSL_KEYFILE.
Aug 23 15:16:32 fedora pasarguard[1475393]: The application will only be accessible through localhost. This means that PasarGuard and subscription URLs will not be accessible externally.
Aug 23 15:16:32 fedora pasarguard[1475393]: 
Aug 23 15:16:32 fedora pasarguard[1475393]: If you need external access, please provide the SSL files to allow the server to bind to 0.0.0.0. Alternatively, you can run the server on localhost or a Unix socket a>
Aug 23 15:16:32 fedora pasarguard[1475393]: 
Aug 23 15:16:32 fedora pasarguard[1475393]: If you wish to continue without SSL, you can use SSH port forwarding to access the application from your machine. note that in this case, subscription functionality wi>
Aug 23 15:16:32 fedora pasarguard[1475393]: 
Aug 23 15:16:32 fedora pasarguard[1475393]: Use the following command:
Aug 23 15:16:32 fedora pasarguard[1475393]: 
Aug 23 15:16:32 fedora pasarguard[1475393]: ssh -L 8000:localhost:8000 user@server
Aug 23 15:16:32 fedora pasarguard[1475393]: 
Aug 23 15:16:32 fedora pasarguard[1475393]: Then, navigate to http://localhost:8000 on your computer.
Aug 23 15:16:32 fedora pasarguard[1475393]:             
Aug 23 15:16:39 fedora pasarguard[1475393]: INFO:     2026-08-23 10:16:39,632 - Started server process [1]
Aug 23 15:16:39 fedora pasarguard[1475393]: INFO:     2026-08-23 10:16:39,632 - Waiting for application startup.
Aug 23 15:16:39 fedora pasarguard[1475393]: INFO:     2026-08-23 10:16:39,720 - Node-checker - Starting nodes' cores...
Aug 23 15:16:39 fedora pasarguard[1475393]: WARNING:  2026-08-23 10:16:39,727 - Node-checker - Attention: You have no node, you need to have at least one node
Aug 23 15:16:39 fedora pasarguard[1475393]: INFO:     2026-08-23 10:16:39,728 - App-factory - PasarGuard v5.2.1 (all-in-one)
Aug 23 15:16:39 fedora pasarguard[1475393]: INFO:     2026-08-23 10:16:39,728 - Application startup complete.
Aug 23 15:16:39 fedora pasarguard[1475393]: INFO:     2026-08-23 10:16:39,729 - Uvicorn running on http://localhost:8000
```

## Notes for reviewers

**First of all:** I fully agree with the mandatory SSL policy. I think it's an excellent safeguard for people's security, and that's exactly why I did **not** add any mention of this flag to `.env.example` or the SSL warning message. I don't want users casually bypassing it.

The flag exists only for real edge cases. Because running HTTPS **inside a private network** between the PasarGuard container and the reverse proxy container is meaningless, the TLS termination belongs at the host proxy, not inside the container. For people who hit this and know exactly what they're doing, the mandatory policy otherwise blocks a legitimate deployment with zero security benefit.

Average developer, have no problem with cloning repository, removing checks and building image locally (Even non-technical person can do it with the help of AI), but it just adds unwanted work for them. That's exactly why this PR was made, developers who understand things they do, can easily discover this flag and use it, while remaining out of scope for average Joe, since it never gets mentioned anywhere and isn't available directly in `.env` file by default. However, happy to add and properly document this feature, if maintainers prefer it this way.

Thanks for your work!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to start the server without SSL certificate and key files.
  * When enabled, the server runs over plain HTTP using the configured socket or host and port.

* **Bug Fixes**
  * Improved startup handling for deployments that do not provide TLS credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->