### PR TITLE
fix(dashboard): handle Telegram Mini App launch hash

### DIFF
--- a/dashboard/src/app/router.tsx
+++ b/dashboard/src/app/router.tsx
@@ -8,6 +8,7 @@ import { RouteErrorPage } from '@/components/layout/error-page'
 import { TabbedRouteSuspenseFallback } from '@/components/layout/tabbed-route-suspense-fallback'
 import { lazyWithChunkRecovery } from '@/utils/chunk-recovery'
 import { isAuthenticationError } from '@/utils/error-utils'
+import { prepareTelegramMiniAppRoute } from '@/utils/telegram-mini-app'
 // Replace direct imports with lazy imports for route-level components
 const CoresLayout = lazyWithChunkRecovery(() => import('@/pages/_dashboard.nodes.cores'))
 const CoresIndex = lazyWithChunkRecovery(() => import('@/pages/_dashboard.nodes.cores._index'))
@@ -44,6 +45,8 @@ const UserTemplates = lazyWithChunkRecovery(() => import('../pages/_dashboard.te
 const ClientTemplates = lazyWithChunkRecovery(() => import('../pages/_dashboard.templates.client'))
 const Users = lazyWithChunkRecovery(() => import('../pages/_dashboard.users'))
 const Login = lazyWithChunkRecovery(() => import('../pages/login'))
+
+prepareTelegramMiniAppRoute()
 
 // Component to handle default settings routing based on user permissions
 function SettingsIndex() {

--- a/dashboard/src/pages/login.tsx
+++ b/dashboard/src/pages/login.tsx
@@ -13,7 +13,6 @@ import { $fetch } from '@/service/http'
 import { getAuthToken, removeAuthToken, setAuthToken } from '@/utils/authStorage'
 import { queryClient } from '@/utils/query-client'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { retrieveRawInitData } from '@telegram-apps/sdk'
 import { ArrowLeft, CircleAlertIcon, KeyRound, LogInIcon, RotateCcw, ShieldCheck, Trash2, UserRoundKey } from 'lucide-react'
 import { FC, useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -23,6 +22,7 @@ import { toast } from 'sonner'
 import { z } from 'zod'
 import useDirDetection from '@/hooks/use-dir-detection'
 import { passwordValidation } from '@/features/admins/forms/admin-form'
+import { getTelegramMiniAppInitData } from '@/utils/telegram-mini-app'
 
 const schema = z.object({
   username: z.string().min(1, 'login.fieldRequired'),
@@ -129,15 +129,8 @@ export const Login: FC = () => {
     resolver: zodResolver(schema),
   })
 
-  let isTelegram = false
-  let initDataRaw = ''
-  try {
-    initDataRaw = retrieveRawInitData() || ''
-    isTelegram = !!initDataRaw
-  } catch (e) {
-    isTelegram = false
-    initDataRaw = ''
-  }
+  const initDataRaw = getTelegramMiniAppInitData()
+  const isTelegram = !!initDataRaw
 
   useEffect(() => {
     if (location.pathname !== '/login') {

--- a/dashboard/src/utils/telegram-mini-app.ts
+++ b/dashboard/src/utils/telegram-mini-app.ts
@@ -1,0 +1,30 @@
+import { retrieveRawInitData } from '@telegram-apps/sdk'
+
+let initDataFromLaunchHash = ''
+
+/**
+ * Telegram puts Mini App launch parameters in the URL fragment. Capture the
+ * signed init data before the hash router interprets that fragment as a route,
+ * then point the router at the login page that performs the token exchange.
+ */
+export function prepareTelegramMiniAppRoute() {
+  if (typeof window === 'undefined') return
+
+  const launchParams = new URLSearchParams(window.location.hash.replace(/^#\??/, ''))
+  const initData = launchParams.get('tgWebAppData')
+  if (!initData) return
+
+  initDataFromLaunchHash = initData
+  const { pathname, search } = window.location
+  window.history.replaceState(window.history.state, '', `${pathname}${search}#/login`)
+}
+
+export function getTelegramMiniAppInitData() {
+  if (initDataFromLaunchHash) return initDataFromLaunchHash
+
+  try {
+    return retrieveRawInitData() || ''
+  } catch {
+    return ''
+  }
+}


### PR DESCRIPTION
## Summary
- capture Telegram Mini App init data before React Router consumes the URL fragment
- normalize Telegram launch fragments to the login route
- reuse the captured payload for the Mini App token exchange

## Verification
- production dashboard build passes
- focused launch-fragment check confirms the payload is preserved and the route becomes #/login

Fixes #828