### PR TITLE
fix(dashboard): cancel obsolete API requests at the HTTP transport

### DIFF
--- a/dashboard/src/service/http.ts
+++ b/dashboard/src/service/http.ts
@@ -39,7 +39,7 @@ type OvalFetcherParams = FetchOptions<'json'> & {
   params?: Record<string, unknown>
   data?: FetchOptions<'json'>['body']
 }
-export const orvalFetcher = async <T>({ url, method, params, data: body }: OvalFetcherParams): Promise<T> => {
+export const orvalFetcher = async <T>({ url, method, params, data: body, signal }: OvalFetcherParams): Promise<T> => {
   if (method === 'GET') {
     // 1. If we have data in a GET request, it means arguments were shifted or
     // we manually passed data to rescue dropped parameters.
@@ -67,6 +67,7 @@ export const orvalFetcher = async <T>({ url, method, params, data: body }: OvalF
     method,
     params,
     body,
+    signal,
   })
 }
 


### PR DESCRIPTION
## Summary

Pass the generated client's `AbortSignal` through `orvalFetcher` to `ofetch`. When a user changes search/page parameters or leaves a screen, TanStack Query already cancels the obsolete query, but the HTTP adapter previously discarded its signal and let the network request finish.

The latest active request still completes normally. This fixes the shared transport used by generated API queries with a two-line change.

### Before / after

Local integration comparison against `dev` (`234ab68c`), using the actual generated `getGetUsersQueryOptions`, TanStack `QueryObserver`, `orvalFetcher`, and `ofetch` with a loopback HTTP server:

| Scenario / metric | Before | After |
| --- | ---: | ---: |
| 10 successive search keys: HTTP requests started | 10 | 10 |
| Superseded requests canceled at HTTP transport | 0 | 9 |
| Full responses sent by the server | 10 | 1 |
| Synthetic response body bytes sent | 655,750 | 65,575 |
| Unsubscribe after starting all 10: requests canceled | 0 | 10 |
| Unsubscribe after starting all 10: full responses sent | 10 | 0 |
| Already-aborted signal: requests reaching the server | 1 | 0 |
| Already-aborted signal: returned promise | Fulfilled | Rejected |

For each search key, the harness waited until its request reached the server before switching keys. Responses were held until all 10 requests had started. Each response body was 65,575 bytes of synthetic JSON. Cancellation was measured using premature HTTP response-close events, not just canceled query state. The search scenario sent 90% fewer response body bytes in this controlled test; this is not a production performance estimate.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [ ] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed. (Not applicable.)
- [x] I checked database migrations when models or schema changed. (Not applicable.)
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

- Ran a standalone local integration harness before and after the patch with Node 24.15.0 and the installed dashboard dependencies. Auth-token/timezone utilities were stubbed; query cancellation and HTTP transport used the real implementation. The harness is a local experiment, not a committed test suite; no test framework was added.
- Confirmed the latest search still succeeds, canceled requests are not retried, and pre-aborted requests never reach the server after the change.
- Regression checks passed for GET parameter normalization (object and sort-array inputs), POST JSON bodies, authentication/timezone headers, and HTTP 401 login redirects. Cancellation did not redirect to login.
- `git diff --check`: passed.
- `node node_modules/typescript/bin/tsc -p tsconfig.app.json --noEmit --pretty false` (from `dashboard`): fails on existing project diagnostics. A TypeScript compiler API comparison found the same 28 diagnostics before and after, with none in `src/service/http.ts`.

Suggested manual browser check (not run): throttle the network in DevTools, change user search/page parameters while a request is pending, and check that obsolete requests show as canceled while the final request succeeds. Navigate away with a request pending and check that it is canceled as well.

## Screenshots

Not applicable; no visual UI changes.

## Notes for reviewers

This forwards the existing optional signal without changing the generated API file or other request options. It is independent of the user/node usage aggregation PRs. HTTP cancellation does not guarantee that backend or database work which has already started is interrupted.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for canceling in-progress network requests, helping prevent unnecessary work when requests are no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->