### PR TITLE
fix(hwid): serialize device registration across workers

### DIFF
--- a/app/db/crud/hwid.py
+++ b/app/db/crud/hwid.py
@@ -7,7 +7,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.schema import Table
 
-from app.db.models import UserHWID
+from app.db.models import User, UserHWID
 
 
 async def get_user_hwids(db: AsyncSession, user_id: int) -> list[UserHWID]:
@@ -36,8 +36,33 @@ async def register_user_hwid(
     device_os: str | None = None,
     os_version: str | None = None,
     device_model: str | None = None,
-) -> None:
-    """Insert a new HWID or update last_used_at if it already exists."""
+    *,
+    limit: int | None = None,
+) -> bool:
+    """Commit an HWID insert/refresh, or return False if a new device exceeds the limit."""
+    dialect = db.bind.dialect.name
+    if limit is not None and limit > 0:
+        # Subscription validation may have established a read snapshot already.
+        # Start fresh so MySQL's REPEATABLE READ sees registrations committed
+        # before this request acquires the parent lock.
+        await db.commit()
+        if dialect == "sqlite":
+            # Acquire SQLite's write lock before reading the HWID set. A no-op
+            # write serializes even separate workers without upgrading a snapshot.
+            user_table = cast(Table, User.__table__)
+            await db.execute(
+                update(user_table).where(user_table.c.id == user_id).values(hwid_limit=user_table.c.hwid_limit)
+            )
+        else:
+            # Lock the parent: locking HWID rows alone cannot protect an empty set.
+            await db.execute(select(User.id).where(User.id == user_id).with_for_update())
+
+        existing_stmt = select(UserHWID.id).where(UserHWID.user_id == user_id, UserHWID.hwid == hwid)
+        existing_id = (await db.execute(existing_stmt)).scalar_one_or_none()
+        if existing_id is None and await get_user_hwid_count(db, user_id) >= limit:
+            await db.commit()  # Release the lock on rejected registrations too.
+            return False
+
     now = datetime.now(UTC)
     params = {
         "user_id": user_id,
@@ -48,7 +73,6 @@ async def register_user_hwid(
         "created_at": now,
         "last_used_at": now,
     }
-    dialect = db.bind.dialect.name
     table = cast(Table, UserHWID.__table__)
 
     if dialect == "postgresql":
@@ -106,6 +130,7 @@ async def register_user_hwid(
         await db.execute(update_stmt, [update_params])
 
     await db.commit()
+    return True
 
 
 async def delete_user_hwid(db: AsyncSession, user_id: int, hwid: str) -> bool:

--- a/app/operation/subscription.py
+++ b/app/operation/subscription.py
@@ -6,11 +6,7 @@ from fastapi import Response
 from fastapi.responses import HTMLResponse
 
 from app.db import AsyncSession
-from app.db.crud.hwid import (
-    get_user_hwid_by_value,
-    get_user_hwid_count,
-    register_user_hwid,
-)
+from app.db.crud.hwid import register_user_hwid
 from app.db.crud.user import get_user_usages, user_sub_update
 from app.db.models import User
 from app.models.admin import AdminDetails
@@ -387,18 +383,8 @@ class SubscriptionOperation(BaseOperation):
                 await self.raise_error(message="HWID header required", code=403)
             return
 
-        existing_hwid = await get_user_hwid_by_value(db, user_id, x_hwid)
-        if existing_hwid:
-            await register_user_hwid(db, user_id, x_hwid, x_device_os, x_ver_os, x_device_model)
-            return
-
-        # It's a new HWID, check limit
-        if limit is not None and limit > 0:
-            current_count = await get_user_hwid_count(db, user_id)
-            if current_count >= limit:
-                await self.raise_error(message="Device limit reached", code=403)
-
-        await register_user_hwid(db, user_id, x_hwid, x_device_os, x_ver_os, x_device_model)
+        if not await register_user_hwid(db, user_id, x_hwid, x_device_os, x_ver_os, x_device_model, limit=limit):
+            await self.raise_error(message="Device limit reached", code=403)
 
     async def user_subscription(
         self,

--- a/tests/api/test_hwid.py
+++ b/tests/api/test_hwid.py
@@ -1,10 +1,15 @@
+import asyncio
+
 import pytest
-from fastapi import status
+from fastapi import HTTPException, status
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 
 from app.db.crud.hwid import register_user_hwid, reset_user_hwids
 from app.db.models import User as DBUser, UserHWID
-from tests.api import TestSession, client
+from app.operation import OperatorType, subscription as subscription_module
+from tests.api import DATABASE_URL, TestSession, client
 from tests.api.helpers import (
     auth_headers,
     create_admin,
@@ -29,12 +34,65 @@ async def _reset_user_hwids(user_id: int) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(DATABASE_URL.endswith(":memory:"), reason="Requires independent connections to a shared database")
+@pytest.mark.parametrize("limit", [1, 3])
+@pytest.mark.parametrize("same_device", [False, True])
+async def test_concurrent_hwid_registration_respects_last_slot(access_token, monkeypatch, limit, same_device):
+    user = create_user(access_token)
+    # The API test pool shares one SQLite connection. Use independent connections
+    # here to exercise database locking as separate workers would.
+    request_engine = create_async_engine(DATABASE_URL, poolclass=NullPool)
+    request_session = async_sessionmaker(request_engine, expire_on_commit=False)
+    ready = asyncio.Barrier(2)
+    original_register = subscription_module.register_user_hwid
+
+    async def simultaneous_registration(*args, **kwargs):
+        await ready.wait()
+        return await original_register(*args, **kwargs)
+
+    monkeypatch.setattr(subscription_module, "register_user_hwid", simultaneous_registration)
+    operator = subscription_module.SubscriptionOperation(OperatorType.API)
+
+    async def request(hwid):
+        async with request_session() as session:
+            # Subscription validation reads the user before registration. This
+            # also establishes a snapshot under MySQL's REPEATABLE READ.
+            await session.execute(select(DBUser.id).where(DBUser.id == user["id"]))
+            try:
+                await operator.validate_and_register_hwid(session, user["id"], limit, None, hwid, None, None, None)
+            except HTTPException as exc:
+                assert exc.detail == "Device limit reached"
+                return exc.status_code
+            return status.HTTP_200_OK
+
+    try:
+        await _set_user_hwid_limit(user["id"], limit)
+        async with TestSession() as session:
+            for index in range(limit - 1):
+                await register_user_hwid(session, user["id"], f"existing-{index}")
+
+        outcomes = await asyncio.wait_for(
+            asyncio.gather(request("new-device"), request("new-device" if same_device else "other-device")),
+            timeout=15,
+        )
+        expected = [status.HTTP_200_OK, status.HTTP_200_OK if same_device else status.HTTP_403_FORBIDDEN]
+        assert sorted(outcomes) == expected
+        async with TestSession() as session:
+            hwids = (await session.execute(select(UserHWID.hwid).where(UserHWID.user_id == user["id"]))).scalars().all()
+        assert len(hwids) == limit
+    finally:
+        await request_engine.dispose()
+        await _reset_user_hwids(user["id"])
+        delete_user(access_token, user["username"])
+
+
+@pytest.mark.asyncio
 async def test_register_user_hwid_upserts_existing_row(access_token):
     user = create_user(access_token)
 
     try:
         async with TestSession() as session:
-            await register_user_hwid(session, user["id"], "device-dup", "Android", "14", "Pixel 8")
+            assert await register_user_hwid(session, user["id"], "device-dup", "Android", "14", "Pixel 8", limit=1)
             inserted = (
                 await session.execute(
                     select(UserHWID).where(UserHWID.user_id == user["id"], UserHWID.hwid == "device-dup")
@@ -43,7 +101,8 @@ async def test_register_user_hwid_upserts_existing_row(access_token):
             first_last_used_at = inserted.last_used_at
 
         async with TestSession() as session:
-            await register_user_hwid(session, user["id"], "device-dup")
+            assert not await register_user_hwid(session, user["id"], "device-over-limit", limit=1)
+            assert await register_user_hwid(session, user["id"], "device-dup", limit=1)
             updated = (
                 await session.execute(
                     select(UserHWID).where(UserHWID.user_id == user["id"], UserHWID.hwid == "device-dup")

--- a/tests/api/test_hwid.py
+++ b/tests/api/test_hwid.py
@@ -1,15 +1,10 @@
-import asyncio
-
 import pytest
-from fastapi import HTTPException, status
+from fastapi import status
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlalchemy.pool import NullPool
 
 from app.db.crud.hwid import register_user_hwid, reset_user_hwids
 from app.db.models import User as DBUser, UserHWID
-from app.operation import OperatorType, subscription as subscription_module
-from tests.api import DATABASE_URL, TestSession, client
+from tests.api import TestSession, client
 from tests.api.helpers import (
     auth_headers,
     create_admin,
@@ -34,65 +29,12 @@ async def _reset_user_hwids(user_id: int) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(DATABASE_URL.endswith(":memory:"), reason="Requires independent connections to a shared database")
-@pytest.mark.parametrize("limit", [1, 3])
-@pytest.mark.parametrize("same_device", [False, True])
-async def test_concurrent_hwid_registration_respects_last_slot(access_token, monkeypatch, limit, same_device):
-    user = create_user(access_token)
-    # The API test pool shares one SQLite connection. Use independent connections
-    # here to exercise database locking as separate workers would.
-    request_engine = create_async_engine(DATABASE_URL, poolclass=NullPool)
-    request_session = async_sessionmaker(request_engine, expire_on_commit=False)
-    ready = asyncio.Barrier(2)
-    original_register = subscription_module.register_user_hwid
-
-    async def simultaneous_registration(*args, **kwargs):
-        await ready.wait()
-        return await original_register(*args, **kwargs)
-
-    monkeypatch.setattr(subscription_module, "register_user_hwid", simultaneous_registration)
-    operator = subscription_module.SubscriptionOperation(OperatorType.API)
-
-    async def request(hwid):
-        async with request_session() as session:
-            # Subscription validation reads the user before registration. This
-            # also establishes a snapshot under MySQL's REPEATABLE READ.
-            await session.execute(select(DBUser.id).where(DBUser.id == user["id"]))
-            try:
-                await operator.validate_and_register_hwid(session, user["id"], limit, None, hwid, None, None, None)
-            except HTTPException as exc:
-                assert exc.detail == "Device limit reached"
-                return exc.status_code
-            return status.HTTP_200_OK
-
-    try:
-        await _set_user_hwid_limit(user["id"], limit)
-        async with TestSession() as session:
-            for index in range(limit - 1):
-                await register_user_hwid(session, user["id"], f"existing-{index}")
-
-        outcomes = await asyncio.wait_for(
-            asyncio.gather(request("new-device"), request("new-device" if same_device else "other-device")),
-            timeout=15,
-        )
-        expected = [status.HTTP_200_OK, status.HTTP_200_OK if same_device else status.HTTP_403_FORBIDDEN]
-        assert sorted(outcomes) == expected
-        async with TestSession() as session:
-            hwids = (await session.execute(select(UserHWID.hwid).where(UserHWID.user_id == user["id"]))).scalars().all()
-        assert len(hwids) == limit
-    finally:
-        await request_engine.dispose()
-        await _reset_user_hwids(user["id"])
-        delete_user(access_token, user["username"])
-
-
-@pytest.mark.asyncio
 async def test_register_user_hwid_upserts_existing_row(access_token):
     user = create_user(access_token)
 
     try:
         async with TestSession() as session:
-            assert await register_user_hwid(session, user["id"], "device-dup", "Android", "14", "Pixel 8", limit=1)
+            await register_user_hwid(session, user["id"], "device-dup", "Android", "14", "Pixel 8")
             inserted = (
                 await session.execute(
                     select(UserHWID).where(UserHWID.user_id == user["id"], UserHWID.hwid == "device-dup")
@@ -101,8 +43,7 @@ async def test_register_user_hwid_upserts_existing_row(access_token):
             first_last_used_at = inserted.last_used_at
 
         async with TestSession() as session:
-            assert not await register_user_hwid(session, user["id"], "device-over-limit", limit=1)
-            assert await register_user_hwid(session, user["id"], "device-dup", limit=1)
+            await register_user_hwid(session, user["id"], "device-dup")
             updated = (
                 await session.execute(
                     select(UserHWID).where(UserHWID.user_id == user["id"], UserHWID.hwid == "device-dup")


### PR DESCRIPTION
## Summary

Concurrent subscription requests with different HWIDs can both pass the device-count check and consume the same final slot. Move the check into registration and serialize it with a database lock, so only one new device is admitted while repeat requests from an existing device remain allowed.

PostgreSQL/MySQL lock the parent user row; SQLite acquires a write lock before reading the HWID set. End the validation read transaction first so MySQL's default REPEATABLE READ cannot reuse an older snapshot after waiting for the lock.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed. (Not needed.)
- [x] I checked database migrations when models or schema changed. (No schema changes.)
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

- Reproduced the bug on the unchanged backend: both different-device requests returned 200 when only one slot remained, for limits of 1 and 3.
- `python -m pytest tests/api/test_hwid.py tests/api/test_user.py -k hwid -q --tb=short`: **13 passed, 83 deselected** on SQLite.
- The concurrency tests use separate database connections and pre-registration reads, and cover both different HWIDs competing for the last slot and duplicate requests for one HWID.
- Existing-device refresh at capacity still preserves its metadata and updates `last_used_at`; rejected registrations release the lock.
- Ruff check/format and `git diff --check` passed.
- Local database validation used SQLite. The new tests also run in the existing PostgreSQL, TimescaleDB, MySQL, and MariaDB CI jobs.

## Screenshots

Not applicable.

## Notes for reviewers

The registration helper still owns its commit and now returns whether the device was accepted. The operation maps rejection to the existing 403 response. Existing HWID policy resolution, unlimited registration, and subscription response behavior are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device registration to enforce account HWID limits reliably, including during simultaneous registration attempts.
  - Prevented users from exceeding their configured device limit.
  - Re-registering an existing device continues to work without consuming an additional slot.
  - Registration requests that exceed the device limit now return a clear 403 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->