### PR TITLE
fix(node): recover from slow Start timeouts

### DIFF
--- a/app/jobs/node_checker.py
+++ b/app/jobs/node_checker.py
@@ -135,12 +135,13 @@ async def process_node_health_check(db_node: Node, node: PasarGuardNode):
             return
 
         # Prefer shared lifecycle state so multi-worker local NOT_CONNECTED does not thrash Start.
-        # Trust observed HEALTHY only if we can attach, or another worker still holds an active lease.
+        # A BROKEN observation with desired HEALTHY can be an ambiguous client-side Start
+        # timeout: the remote core may have completed startup after the panel gave up.
         shared_state = await node.get_lifecycle_state()
         if (
             health is Health.NOT_CONNECTED
             and shared_state is not None
-            and shared_state.observed is LifecycleStatus.HEALTHY
+            and (shared_state.observed is LifecycleStatus.HEALTHY or shared_state.desired is LifecycleStatus.HEALTHY)
         ):
             attached = await NodeOperation._attach_if_running(node, db_node.name)
             if attached is not None:
@@ -154,9 +155,10 @@ async def process_node_health_check(db_node: Node, node: PasarGuardNode):
                 )
                 return
 
-            # Stale HEALTHY (owner gone / core unreachable): fall through to reconnect.
+            # Stale/failed desired-healthy state: fall through to reconnect only after
+            # the attach probe and active-lease check have both failed.
             logger.debug(
-                "[%s] Shared lifecycle HEALTHY but attach failed and no active lease; reconnecting",
+                "[%s] Shared lifecycle desired HEALTHY but attach failed and no active lease; reconnecting",
                 db_node.name,
             )
 

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -50,7 +50,7 @@ class Node(BaseModel):
     data_limit: int = Field(default=0)
     data_limit_reset_strategy: DataLimitResetStrategy = Field(default=DataLimitResetStrategy.no_reset)
     reset_time: int = Field(default=-1)
-    default_timeout: int = Field(default=10, ge=3, le=60)
+    default_timeout: int = Field(default=10, ge=3)
     internal_timeout: int = Field(default=15, ge=3, le=60)
     proxy_url: str | None = Field(default=None, max_length=256)
 
@@ -180,7 +180,7 @@ class NodeModify(NodeCreate):
     data_limit: int | None = None
     data_limit_reset_strategy: DataLimitResetStrategy | None = None
     reset_time: int | None = None
-    default_timeout: int | None = Field(default=None, ge=3, le=60)
+    default_timeout: int | None = Field(default=None, ge=3)
     internal_timeout: int | None = Field(default=None, ge=3, le=60)
 
     model_config = ConfigDict(

--- a/app/operation/node.py
+++ b/app/operation/node.py
@@ -249,7 +249,7 @@ class NodeOperation(BaseOperation):
                 return None
 
             info = await pg_node.info()
-            if info is None or not info.node_version or not info.core_version:
+            if info is None or not info.started or not info.node_version or not info.core_version:
                 return None
 
             await pg_node.connect(info.node_version, info.core_version)
@@ -266,7 +266,10 @@ class NodeOperation(BaseOperation):
     @staticmethod
     async def _start_or_attach_node(pg_node: PasarGuardNode, db_node: Node, core, users: list, backend_type):
         state = await pg_node.get_lifecycle_state()
-        if state is not None and state.observed in (LifecycleStatus.HEALTHY, LifecycleStatus.STARTING):
+        if state is not None and (
+            state.observed in (LifecycleStatus.HEALTHY, LifecycleStatus.STARTING)
+            or state.desired is LifecycleStatus.HEALTHY
+        ):
             attached = await NodeOperation._attach_if_running(pg_node, db_node.name)
             if attached is not None:
                 return attached
@@ -351,6 +354,23 @@ class NodeOperation(BaseOperation):
                 # worker; the next retry cycle will reassess once that operation completes.
                 logger.debug(f'"{db_node.name}" node lifecycle lease is held by another worker, will retry')
                 return
+
+            if e.code == -1:
+                # A timed-out Start has an ambiguous outcome: cancelling the panel-side
+                # request does not guarantee that the remote node stopped starting. Probe
+                # it before reporting an error so a late success is attached instead of
+                # being torn down by the next health-check reconnect.
+                attached = await NodeOperation._attach_if_running(pg_node, db_node.name)
+                if attached is not None:
+                    logger.info(f'Attached to "{db_node.name}" after its Start request timed out')
+                    return {
+                        "node_id": db_node.id,
+                        "status": NodeStatus.connected,
+                        "message": "",
+                        "xray_version": attached.core_version,
+                        "node_version": attached.node_version,
+                        "old_status": old_status,
+                    }
 
             detail = e.detail[:1020] + "..." if len(e.detail) > 1024 else e.detail
 

--- a/dashboard/src/features/nodes/forms/node-form.ts
+++ b/dashboard/src/features/nodes/forms/node-form.ts
@@ -16,7 +16,7 @@ export const nodeFormSchema = z.object({
   data_limit: z.number().min(0).optional().nullable(),
   data_limit_reset_strategy: z.nativeEnum(DataLimitResetStrategy).optional().nullable(),
   reset_time: z.union([z.null(), z.undefined(), z.number().min(-1)]),
-  default_timeout: z.number().min(3, 'Default timeout must be 3 or greater').max(60, 'Default timeout must be 60 or lower').optional(),
+  default_timeout: z.number().min(3, 'Default timeout must be 3 or greater').optional(),
   internal_timeout: z.number().min(3, 'Internal timeout must be 3 or greater').max(60, 'Internal timeout must be 60 or lower').optional(),
   proxy_url: z.string().url('Please enter a valid URL').optional().or(z.literal('')),
 })

--- a/tests/test_node_start_timeout.py
+++ b/tests/test_node_start_timeout.py
@@ -1,0 +1,117 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PasarGuardNodeBridge import Health, NodeAPIError
+from PasarGuardNodeBridge.storage import LifecycleStatus
+from pydantic import ValidationError
+
+from app.db.models import NodeStatus
+from app.jobs import node_checker
+from app.models.node import NodeModify
+from app.operation import node as node_operation_module
+from app.operation.node import NodeOperation
+
+
+def test_default_timeout_allows_slow_node_startup():
+    assert NodeModify(default_timeout=300).default_timeout == 300
+
+    with pytest.raises(ValidationError):
+        NodeModify(default_timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_attach_requires_remote_core_to_be_started():
+    state = SimpleNamespace(
+        observed=LifecycleStatus.BROKEN,
+        desired=LifecycleStatus.HEALTHY,
+        epoch=1,
+    )
+    pg_node = SimpleNamespace(
+        get_lifecycle_state=AsyncMock(return_value=state),
+        info=AsyncMock(
+            return_value=SimpleNamespace(
+                started=False,
+                node_version="0.5.4",
+                core_version="1.0.20260223",
+            )
+        ),
+        connect=AsyncMock(),
+    )
+
+    assert await NodeOperation._attach_if_running(pg_node, "slow-node") is None
+    pg_node.connect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_or_attach_probes_broken_desired_healthy_lifecycle(monkeypatch: pytest.MonkeyPatch):
+    state = SimpleNamespace(observed=LifecycleStatus.BROKEN, desired=LifecycleStatus.HEALTHY)
+    pg_node = SimpleNamespace(get_lifecycle_state=AsyncMock(return_value=state), start=AsyncMock())
+    attached = object()
+    attach = AsyncMock(return_value=attached)
+    monkeypatch.setattr(NodeOperation, "_attach_if_running", attach)
+
+    result = await NodeOperation._start_or_attach_node(
+        pg_node,
+        SimpleNamespace(name="slow-node"),
+        object(),
+        [],
+        object(),
+    )
+
+    assert result is attached
+    attach.assert_awaited_once_with(pg_node, "slow-node")
+    pg_node.start.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_node_attaches_when_remote_start_finishes_after_timeout(monkeypatch: pytest.MonkeyPatch):
+    pg_node = object()
+    db_node = SimpleNamespace(id=19, name="slow-node", status=NodeStatus.connecting)
+    core = SimpleNamespace(type=object())
+    attached = SimpleNamespace(node_version="0.5.4", core_version="1.0.20260223")
+
+    monkeypatch.setattr(node_operation_module.node_manager, "get_node", AsyncMock(return_value=pg_node))
+    monkeypatch.setattr(
+        NodeOperation,
+        "_start_or_attach_node",
+        AsyncMock(side_effect=NodeAPIError(-1, "Request timed out")),
+    )
+    attach = AsyncMock(return_value=attached)
+    monkeypatch.setattr(NodeOperation, "_attach_if_running", attach)
+
+    result = await NodeOperation.connect_node(db_node, core, [])
+
+    assert result == {
+        "node_id": 19,
+        "status": NodeStatus.connected,
+        "message": "",
+        "xray_version": "1.0.20260223",
+        "node_version": "0.5.4",
+        "old_status": NodeStatus.connecting,
+    }
+    attach.assert_awaited_once_with(pg_node, "slow-node")
+
+
+@pytest.mark.asyncio
+async def test_health_check_attaches_ambiguous_timed_out_start_before_reconnect(monkeypatch: pytest.MonkeyPatch):
+    state = SimpleNamespace(observed=LifecycleStatus.BROKEN, desired=LifecycleStatus.HEALTHY)
+    node = MagicMock()
+    node.requires_hard_reset.return_value = False
+    node.get_lifecycle_state = AsyncMock(return_value=state)
+    db_node = SimpleNamespace(id=19, name="slow-node", status=NodeStatus.error)
+
+    monkeypatch.setattr(
+        node_checker,
+        "verify_node_backend_health",
+        AsyncMock(return_value=(Health.NOT_CONNECTED, None, None)),
+    )
+    attach = AsyncMock(return_value=object())
+    monkeypatch.setattr(NodeOperation, "_attach_if_running", attach)
+    reconnect = AsyncMock()
+    monkeypatch.setattr(node_checker.node_operator, "connect_single_node", reconnect)
+
+    await node_checker.process_node_health_check(db_node, node)
+
+    attach.assert_awaited_once_with(node, "slow-node")
+    reconnect.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Remove the artificial 60-second upper bound from node `default_timeout` in both the API validation and dashboard form.
- Treat a timed-out `Start` RPC as an ambiguous outcome: probe `GetBaseInfo` and attach if the remote core finished starting.
- Let the health checker recover lifecycle state with `observed=BROKEN` and `desired=HEALTHY` before issuing a destructive reconnect.
- Require `GetBaseInfo.started` before attaching to avoid marking a stopped core healthy.
- Add regression tests for slow startup, late success, lifecycle reconciliation, and reconnect suppression.

Closes #861

## Why

The panel used `default_timeout` for `Start`, while both backend and frontend capped that value at 60 seconds. When a large WireGuard core finished just after that deadline, the bridge recorded the lifecycle as `BROKEN` even though the remote core was already running. The next health tick then replaced the controller, sent `Stop`, and started the core again, producing the reported loop.

A client-side timeout does not prove the remote operation failed. This change reconciles the actual remote state before returning an error or starting another lifecycle operation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [x] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] Documentation, translations, or examples are not needed for this change.
- [x] No database migration is needed; the persisted column remains an integer.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

- `python -m ruff check --no-fix app/models/node.py app/operation/node.py app/jobs/node_checker.py tests/test_node_start_timeout.py`
- `python -m pytest -q tests/test_node_start_timeout.py tests/test_connect_concurrency.py tests/test_node_manager.py tests/test_nats_node_memory.py` — **15 passed**
- `prettier --check dashboard/src/features/nodes/forms/node-form.ts`

The full frontend typecheck is currently blocked by unrelated errors already present on `dev`. The full API suite is also blocked in this local environment by the existing `access_token` fixture failing to authenticate `testadmin`.

## Screenshots

Not applicable.

## Notes for reviewers

The database schema is unchanged. Existing timeout values remain valid, while operators with large cores can now configure values above 60 seconds. The recovery path also prevents a late successful startup from being immediately followed by `Stop` and another full `Start`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Node startup and connection handling now better recovers from ambiguous or timed-out start operations when the node is already healthy or running.
  - Health checks can confirm an active node connection before attempting a reconnect.

- **Bug Fixes**
  - Reduced unnecessary connection failures and reconnect attempts after remote node startup timeouts.
  - Improved handling of nodes with inconsistent lifecycle status.

- **Validation**
  - Increased the maximum allowed node default timeout beyond 60 seconds while retaining the minimum of 3 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->