### PR TITLE
fix(core-editor): preserve valid Hysteria2 outbounds

### DIFF
--- a/dashboard/src/features/core-editor/components/xray/xray-outbounds-section.tsx
+++ b/dashboard/src/features/core-editor/components/xray/xray-outbounds-section.tsx
@@ -33,6 +33,7 @@ import { remapIndexAfterArrayMove } from '@/features/core-editor/kit/remap-index
 import {
   flattenOutboundSettings,
   mergeEditorBodyIntoOutbound,
+  normalizeOutboundShareUriForImport,
   normalizeSettingsFromEditor,
   outboundEditorBodyFromOutbound,
   stripEmptyStreamSettingsFromRecord,
@@ -74,7 +75,7 @@ const OUTBOUND_SETTINGS_KIT_BLOCKLIST = new Set(['testseed'])
 
 /**
  * Kit parity keys to hide in the outbound form (we render dedicated controls instead), or omit from JSON.
- * - hysteria: `version: 2` is implied by Xray.
+ * - hysteria: `version: 2` is fixed and persisted automatically.
  * - loopback: inbound tag picklist is filled from profile inbounds.
  */
 const OUTBOUND_HIDDEN_SETTINGS_KEYS: Partial<Record<string, ReadonlySet<string>>> = {
@@ -743,7 +744,7 @@ export function XrayOutboundsSection({ headerAddPulse, headerAddEpoch }: XrayOut
     const raw = uriDraft.trim()
     if (!raw || !ob || ob.protocol === 'unmanaged') return
     try {
-      const imported = generateXrayOutboundFromUri(raw) as Outbound
+      const imported = generateXrayOutboundFromUri(normalizeOutboundShareUriForImport(raw)) as Outbound
       const merged = { ...(ob as object), ...(imported as object) } as Outbound
       const normalized = stripSparseOutboundEnvelope({
         ...merged,

--- a/dashboard/src/features/core-editor/kit/outbound-editor-json.ts
+++ b/dashboard/src/features/core-editor/kit/outbound-editor-json.ts
@@ -137,11 +137,22 @@ export function flattenOutboundSettings(ob: Outbound): Record<string, unknown> {
   return { ...raw }
 }
 
-/** Xray Hysteria outbound is v2-only; `version: 2` is implied — omit from saved JSON / editor body. */
-export function stripHysteriaOutboundRedundantVersion(settings: Record<string, unknown>): Record<string, unknown> {
-  if (settings.version !== 2 && settings.version !== '2') return settings
-  const { version: _removed, ...rest } = settings
-  return rest
+/** Xray rejects Hysteria outbound settings unless the required v2 discriminator is present. */
+export function normalizeHysteriaOutboundSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  return { ...settings, version: 2 }
+}
+
+/** Hysteria2 share links imply TLS even though they commonly omit the generic `security` query parameter. */
+export function normalizeOutboundShareUriForImport(uri: string): string {
+  const schemeEnd = uri.indexOf(':')
+  const scheme = schemeEnd >= 0 ? uri.slice(0, schemeEnd).toLowerCase() : ''
+  if (scheme !== 'hysteria2' && scheme !== 'hy2') return uri
+
+  const parsed = new URL(uri)
+  if (!parsed.searchParams.has('security')) {
+    parsed.searchParams.set('security', 'tls')
+  }
+  return parsed.toString()
 }
 
 /** Map mistaken `rewrite*` keys (older UI) onto Xray `DNSOutboundConfig` (`network`, `address`, `port`). */
@@ -212,7 +223,7 @@ export function outboundEditorBodyFromOutbound(ob: Outbound): Record<string, unk
     return { protocol: 'unmanaged', tag: ob.tag, raw: (ob as { raw: unknown }).raw }
   }
   const flat = flattenOutboundSettings(ob) as Record<string, unknown>
-  const settingsBody = ob.protocol === 'hysteria' ? stripHysteriaOutboundRedundantVersion(flat) : ob.protocol === 'dns' ? pruneDnsOutboundSettings(flat) : flat
+  const settingsBody = ob.protocol === 'hysteria' ? normalizeHysteriaOutboundSettings(flat) : ob.protocol === 'dns' ? pruneDnsOutboundSettings(flat) : flat
   const body: Record<string, unknown> = {
     protocol: ob.protocol,
     tag: ob.tag,
@@ -284,7 +295,7 @@ export function normalizeSettingsFromEditor(protocol: string, settings: Record<s
     return { ...settings }
   }
   if (protocol === 'hysteria') {
-    return stripHysteriaOutboundRedundantVersion({ ...settings })
+    return normalizeHysteriaOutboundSettings(settings)
   }
   if (protocol === 'dns') {
     return pruneDnsOutboundSettings({ ...settings })


### PR DESCRIPTION
## Summary
- keep Xray's required `settings.version: 2` on Hysteria outbounds instead of stripping it on edit/save
- treat Hysteria2 share links without a generic `security` query parameter as TLS, so `sni` and the related TLS settings are imported
- preserve an explicitly supplied `security` value

Fixes #867

## Validation
- reproduced the broken output with the exact share-link shape from #867
- regression assertions cover the outbound version, TLS security/SNI, transport version, and FinalMask preservation
- dashboard production build completes successfully

## Existing checks
- full `tsc -b` is currently blocked by unrelated type errors already present on `dev`
- the repository ESLint config currently cannot load its undeclared `@eslint/js` package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound share-link imports by normalizing links before parsing.
  * Hysteria outbound settings now consistently include the required version value.
  * Hysteria2 share links missing a security setting now default to TLS during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->