### PR TITLE
fix(core-editor): persist inbound FinalMask QUIC edits

### DIFF
--- a/dashboard/src/features/core-editor/components/xray/xray-inbounds-section.tsx
+++ b/dashboard/src/features/core-editor/components/xray/xray-inbounds-section.tsx
@@ -1882,8 +1882,16 @@ export function XrayInboundsSection({ headerAddPulse, headerAddEpoch }: XrayInbo
     const baseRec = { ...(inbound as Record<string, unknown>) }
     const prevSa = (baseRec.streamAdvanced as Record<string, unknown> | undefined) ?? {}
     const sa = { ...prevSa }
-    if (next === undefined) delete sa.finalmask
-    else sa.finalmask = next
+    if (next === undefined) {
+      delete sa.finalmask
+      delete sa.quicParams
+    } else {
+      sa.finalmask = next
+      // The kit importer also exposes finalmask.quicParams as a typed sibling.
+      // Keep that copy in sync because the compiler gives it precedence over finalmask.quicParams.
+      if (isPlainRecord(next.quicParams)) sa.quicParams = { ...next.quicParams }
+      else delete sa.quicParams
+    }
     if (Object.keys(sa).length === 0) delete baseRec.streamAdvanced
     else baseRec.streamAdvanced = sa
     // Prefer canonical finalmask over legacy hysteria transport.udpmasks.


### PR DESCRIPTION
## Summary
- keep the typed inbound QUIC settings synchronized with FinalMask form edits
- clear the typed QUIC copy when FinalMask or its QUIC section is removed
- prevent imported Hysteria2 values from overriding newer UI edits during config compilation

## Root cause
The Xray config kit imports finalmask.quicParams into both the raw finalmask object and a typed streamAdvanced.quicParams sibling. The inbound form only updated the raw copy, while the compiler gives the typed sibling precedence. As a result, an imported value such as congestion: brutal overwrote a later UI change to bbr.

## Validation
- reproduced the issue using an imported Hysteria2 inbound with congestion: brutal
- verified changing it to bbr and adding keepAlivePeriod persists in compiled JSON
- verified disabling FinalMask removes the compiled finalmask block
- npm exec -- tsc --noEmit
- npm run build

Fixes #870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Kept QUIC parameters synchronized when updating inbound final mask settings.
  - Removed associated QUIC parameters when the final mask is cleared.
  - Prevented stale or invalid QUIC parameter values from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->