### PR TITLE
fix(security): bind generated Xray client inbounds to loopback

### DIFF
--- a/app/db/migrations/versions/a8c2d491e705_bind_xray_client_inbounds_to_loopback.py
+++ b/app/db/migrations/versions/a8c2d491e705_bind_xray_client_inbounds_to_loopback.py
@@ -1,0 +1,89 @@
+"""Bind generated Xray client proxy inbounds to loopback.
+
+Revision ID: a8c2d491e705
+Revises: 8e2f1a9c4b70
+Create Date: 2026-08-09
+"""
+
+import re
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a8c2d491e705"
+down_revision = "8e2f1a9c4b70"
+branch_labels = None
+depends_on = None
+
+
+client_templates = sa.table(
+    "client_templates",
+    sa.column("id", sa.Integer()),
+    sa.column("template_type", sa.String()),
+    sa.column("content", sa.Text()),
+    sa.column("is_system", sa.Boolean()),
+)
+
+EXPOSED_LISTENER = re.compile(r'("listen"\s*:\s*)"0\.0\.0\.0"')
+INBOUNDS_ARRAY = re.compile(r'"inbounds"\s*:\s*\[')
+
+
+def _json_array_end(content: str, start: int) -> int | None:
+    depth = 0
+    in_string = False
+    escaped = False
+    for index in range(start, len(content)):
+        character = content[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character == "[":
+            depth += 1
+        elif character == "]":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    return None
+
+
+def _bind_client_listeners_to_loopback(content: str) -> str:
+    """Rewrite only exposed Xray client listener values, preserving the template."""
+    match = INBOUNDS_ARRAY.search(content)
+    if not match:
+        return content
+    start = match.end() - 1
+    end = _json_array_end(content, start)
+    if end is None:
+        return content
+    inbounds = EXPOSED_LISTENER.sub(r'\1"127.0.0.1"', content[start:end])
+    return content[:start] + inbounds + content[end:]
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.select(client_templates.c.id, client_templates.c.content).where(
+            client_templates.c.template_type == "xray_subscription",
+            client_templates.c.is_system.is_(True),
+        )
+    ).mappings()
+    for row in rows:
+        content = row["content"]
+        updated_content = _bind_client_listeners_to_loopback(content)
+        if updated_content == content:
+            continue
+        connection.execute(
+            client_templates.update().where(client_templates.c.id == row["id"]).values(content=updated_content)
+        )
+
+
+def downgrade() -> None:
+    # Do not reintroduce an unauthenticated network listener on downgrade.
+    pass

--- a/tests/test_xray_loopback_migration.py
+++ b/tests/test_xray_loopback_migration.py
@@ -1,0 +1,60 @@
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+
+
+def _load_migration_module():
+    path = Path("app/db/migrations/versions/a8c2d491e705_bind_xray_client_inbounds_to_loopback.py")
+    spec = importlib.util.spec_from_file_location("xray_loopback_migration", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_xray_loopback_migration_updates_edited_system_template_without_reformatting(monkeypatch):
+    module = _load_migration_module()
+    canonical = '{"inbounds": [{"listen": "0.0.0.0"}]}'
+    customized = (
+        '{"inbounds":[{"listen":"0.0.0.0", "custom": true}], '
+        '"outbounds": [{"listen": "0.0.0.0"}], "label": "keep 0.0.0.0"}'
+    )
+    already_safe = '{"inbounds": [{"listen": "127.0.0.1", "custom": true}]}'
+
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    templates = sa.Table(
+        "client_templates",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("template_type", sa.String),
+        sa.Column("content", sa.Text),
+        sa.Column("is_system", sa.Boolean),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as connection:
+        connection.execute(
+            templates.insert(),
+            [
+                {"id": 1, "template_type": "xray_subscription", "content": canonical, "is_system": True},
+                {"id": 2, "template_type": "xray_subscription", "content": customized, "is_system": True},
+                {"id": 3, "template_type": "xray_subscription", "content": customized, "is_system": False},
+                {"id": 4, "template_type": "singbox_subscription", "content": customized, "is_system": True},
+                {"id": 5, "template_type": "xray_subscription", "content": already_safe, "is_system": True},
+            ],
+        )
+        monkeypatch.setattr(module.op, "get_bind", lambda: connection)
+
+        module.upgrade()
+
+        contents = dict(connection.execute(sa.select(templates.c.id, templates.c.content)).all())
+
+    assert contents[1] == '{"inbounds": [{"listen": "127.0.0.1"}]}'
+    assert contents[2] == (
+        '{"inbounds":[{"listen":"127.0.0.1", "custom": true}], '
+        '"outbounds": [{"listen": "0.0.0.0"}], "label": "keep 0.0.0.0"}'
+    )
+    assert contents[3] == customized
+    assert contents[4] == customized
+    assert contents[5] == already_safe


### PR DESCRIPTION
## Summary

The seeded Xray client template listens on `0.0.0.0` without authentication. Change its inbound listeners to `127.0.0.1` so importing the subscription does not expose the client's local proxy to its network.

A data migration updates system `xray_subscription` templates while preserving document formatting and text outside `inbounds`. Non-system and non-Xray templates are unchanged; downgrade deliberately does not restore public listeners. Administrators can still intentionally edit their client templates.

## Scope and compatibility

Standalone on current `dev`. This PR owns the loopback migration and its test; the duplicate is removed from #756. It requires no routing, security-stack or Node PR. The migration follows the current `8e2f1a9c4b70` revision.

## Validation

The current five-database CI matrix completes the migrations and loopback regression, then reports 568 passed, 2 skipped and the same unrelated FinalMask fixture failure on each database. That baseline test is fixed separately in #889, whose complete database matrix passes.

- `pytest -q tests/test_xray_loopback_migration.py`: 1 passed, covering system/non-system templates, inbound-only replacement and formatting preservation.
- Fresh SQLite `alembic upgrade head`: passed; `alembic heads` reports one head (`a8c2d491e705`).
- Scoped Ruff and `git diff --check`: passed.

This changes the default binding in existing system templates; maintainers can review that policy independently of the synchronization work.
