### PR TITLE
fix: prevent stale subscription updates from breaking database CI

### DIFF
--- a/app/subscription/sub_update_buffer.py
+++ b/app/subscription/sub_update_buffer.py
@@ -10,10 +10,10 @@ import asyncio
 from datetime import UTC, datetime as dt
 from typing import Any
 
-from sqlalchemy import insert
+from sqlalchemy import insert, select
 
 from app.db import GetDB
-from app.db.models import UserSubscriptionUpdate
+from app.db.models import User, UserSubscriptionUpdate
 from app.lifecycle import on_shutdown, on_startup
 from app.utils.logger import get_logger
 from config import runtime_settings
@@ -87,13 +87,27 @@ async def flush_user_sub_updates() -> int:
             if not _pending:
                 return written
             _flushing = True
-            batch = _pending[:]
-            _pending.clear()
+            batch = _pending[:FLUSH_BATCH_SIZE]
+            del _pending[:FLUSH_BATCH_SIZE]
         try:
             async with GetDB() as db:
-                await db.execute(insert(UserSubscriptionUpdate.__table__), batch)
+                # Users can be deleted after their subscription request was queued.
+                # Lock surviving parents until commit so concurrent deletes cannot
+                # invalidate the foreign keys between this read and the insert.
+                user_ids = sorted({record["user_id"] for record in batch})
+                existing_user_ids = set(
+                    await db.scalars(
+                        select(User.id)
+                        .where(User.id.in_(user_ids))
+                        .order_by(User.id)
+                        .with_for_update(read=True, key_share=True)
+                    )
+                )
+                live_records = [record for record in batch if record["user_id"] in existing_user_ids]
+                if live_records:
+                    await db.execute(insert(UserSubscriptionUpdate.__table__), live_records)
                 await db.commit()
-            written += len(batch)
+            written += len(live_records)
         except Exception:
             async with _lock:
                 _pending[0:0] = batch

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -344,7 +344,7 @@ def test_host_finalmask_new_types(access_token):
                 "type": "noise",
                 "settings": {
                     "reset": "30-60",
-                    "noise": [{"type": "rand", "rand": "1-8192", "delay": "10-20"}],
+                    "noise": [{"type": "array", "packet": [1, 2, 3], "rand": "1-8192", "delay": "10-20"}],
                 },
             },
         ],
@@ -389,6 +389,9 @@ def test_host_finalmask_new_types(access_token):
         assert fm["udp"][0]["type"] == "realm"
         assert fm["udp"][1]["type"] == "mkcp-legacy"
         assert fm["udp"][5]["settings"].get("reset") == "30-60"
+        assert fm["udp"][5]["settings"]["noise"][0]["type"] == "array"
+        assert fm["udp"][5]["settings"]["noise"][0]["packet"] == [1, 2, 3]
+        assert fm["udp"][5]["settings"]["noise"][0]["rand"] == "1-8192"
         assert "apply_to" not in (fm["udp"][5]["settings"].get("noise") or [{}])[0]
     finally:
         client.delete(f"/api/host/{host_id}", headers={"Authorization": f"Bearer {access_token}"})

--- a/tests/test_sub_update_buffer.py
+++ b/tests/test_sub_update_buffer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import delete, event, func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
@@ -21,6 +21,13 @@ async def buffer_db(monkeypatch: pytest.MonkeyPatch):
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def enable_foreign_keys(connection, _record):
+        cursor = connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
     async with engine.begin() as conn:
         await conn.run_sync(base.Base.metadata.create_all)
 
@@ -99,3 +106,31 @@ async def test_flush_failure_requeues(buffer_db, monkeypatch: pytest.MonkeyPatch
     with pytest.raises(SQLAlchemyError):
         await sub_update_buffer.flush_user_sub_updates()
     assert sub_update_buffer.pending_count() == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("include_live_user", [False, True])
+@pytest.mark.parametrize("batch_size", [1, 100])
+async def test_flush_discards_deleted_users(buffer_db, monkeypatch, include_live_user, batch_size):
+    session, user_id = buffer_db
+    deleted_user = User(username="deleted_before_flush")
+    session.add(deleted_user)
+    await session.commit()
+    await sub_update_buffer.queue_user_sub_update(deleted_user.id, "deleted-client")
+    if include_live_user:
+        await sub_update_buffer.queue_user_sub_update(user_id, "live-client")
+
+    await session.execute(delete(User).where(User.id == deleted_user.id))
+    await session.commit()
+    monkeypatch.setattr(sub_update_buffer, "FLUSH_BATCH_SIZE", batch_size)
+
+    assert await sub_update_buffer.flush_user_sub_updates() == int(include_live_user)
+    assert sub_update_buffer.pending_count() == 0
+    rows = (await session.execute(select(UserSubscriptionUpdate))).scalars().all()
+    assert [(row.user_id, row.user_agent) for row in rows] == ([(user_id, "live-client")] if include_live_user else [])
+    await session.commit()
+
+    monkeypatch.setattr(sub_update_buffer, "FLUSH_BATCH_SIZE", 100)
+    await sub_update_buffer.queue_user_sub_update(user_id, "next-client")
+    assert await sub_update_buffer.flush_user_sub_updates() == 1
+    assert sub_update_buffer.pending_count() == 0


### PR DESCRIPTION
﻿## Summary

Buffered subscription updates for users deleted before a flush caused foreign-key violations, requeued the entire batch, and made subscription history and chart endpoints return HTTP 503. Flush bounded batches, discard records whose users no longer exist, and hold shared parent-row locks through insertion and commit to prevent concurrent deletion races. Valid records are preserved and database failures still requeue the batch.

Update the FinalMask API test to use the supported array packet format after the intentional removal of the `rand` noise type, with round-trip assertions for the packet and random length.

Fixes the failures in https://github.com/PasarGuard/panel/actions/runs/34361432753.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed. (Not needed.)
- [x] I checked database migrations when models or schema changed. (No schema changes; migration checks passed.)
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

- PostgreSQL 17 on Linux, Python 3.14: `uv run pytest tests/ -q --tb=short` — 595 passed, 2 skipped.
- SQLite on Windows, Python 3.14: full suite — 593 passed, 2 skipped; subsequently expanded batch-boundary regression coverage passed in the targeted run below and the Linux full suite.
- `uv run --frozen pytest tests/test_sub_update_buffer.py -q --tb=short` — 7 passed. Tests enable SQLite foreign keys and cover deleted-only and mixed batches, batch boundaries, and subsequent flushes. The new deleted-user cases reproduced the foreign-key failure before the fix.
- `alembic upgrade head` and `alembic check` passed on SQLite and PostgreSQL.
- Ruff lint and formatting checks passed for all changed files; `git diff --check` passed.
- A Windows PostgreSQL full run passed all five tests that failed in the linked CI run, but reported 11 failures in time/usage reporting tests. The Linux PostgreSQL full run passed these tests as well.

## Screenshots

Not applicable.

## Notes for reviewers

Targets `pref-boost` and contains only commit `27c80594`. No migrations or API contract changes. The buffer still writes outside the public subscription request path, and transient database errors retain the existing retry behavior.
