### PR TITLE
fix: refresh subscription history snapshots on MySQL and MariaDB

### DIFF
--- a/app/db/crud/user.py
+++ b/app/db/crud/user.py
@@ -1,4 +1,5 @@
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from typing import Literal
@@ -1348,8 +1349,15 @@ async def bulk_revoke_user_sub(
     return users
 
 
-async def _flush_pending_subscription_updates() -> None:
+@asynccontextmanager
+async def _subscription_update_read_session(db: AsyncSession) -> AsyncIterator[AsyncSession]:
+    """Read committed updates without reusing the caller's pre-flush snapshot."""
     await flush_user_sub_updates()
+    # MySQL/MariaDB REPEATABLE READ may already have a snapshot from the
+    # authorization/user lookup. A separate session sees the flushed rows
+    # without committing or rolling back any work owned by the caller.
+    async with AsyncSession(bind=db.bind, expire_on_commit=False) as read_db:
+        yield read_db
 
 
 async def user_sub_update(
@@ -1373,22 +1381,22 @@ async def user_sub_update(
 async def get_users_sub_update_list(
     db: AsyncSession, user_id: int, offset: int = 0, limit: int = 10
 ) -> tuple[Sequence[UserSubscriptionUpdate], int]:
-    await _flush_pending_subscription_updates()
     stmt = (
         select(UserSubscriptionUpdate)
         .where(UserSubscriptionUpdate.user_id == user_id)
         .order_by(desc(UserSubscriptionUpdate.created_at))
     )
 
-    result = await db.execute(select(func.count()).select_from(stmt.subquery()))
-    count = result.scalar() or 0
+    async with _subscription_update_read_session(db) as read_db:
+        result = await read_db.execute(select(func.count()).select_from(stmt.subquery()))
+        count = result.scalar() or 0
 
-    if offset:
-        stmt = stmt.offset(offset)
-    if limit:
-        stmt = stmt.limit(limit)
+        if offset:
+            stmt = stmt.offset(offset)
+        if limit:
+            stmt = stmt.limit(limit)
 
-    result = (await db.execute(stmt)).unique().scalars().all()
+        result = (await read_db.execute(stmt)).unique().scalars().all()
 
     return result, count
 
@@ -1416,7 +1424,6 @@ async def get_users_subscription_agent_counts(
     end: datetime | None = None,
     period: Period | None = None,
 ) -> list[tuple[str, int]]:
-    await _flush_pending_subscription_updates()
     stmt = select(UserSubscriptionUpdate.user_agent, func.count().label("count"))
     from_clause, conditions = _subscription_update_from_clause(user_id=user_id, admin_id=admin_id)
 
@@ -1433,7 +1440,8 @@ async def get_users_subscription_agent_counts(
         stmt = stmt.where(and_(*conditions))
     stmt = stmt.group_by(UserSubscriptionUpdate.user_agent)
 
-    result = await db.execute(stmt)
+    async with _subscription_update_read_session(db) as read_db:
+        result = await read_db.execute(stmt)
     return [(agent, count) for agent, count in result.all()]
 
 
@@ -1446,7 +1454,6 @@ async def get_users_subscription_agent_stats(
     admin_id: int | None = None,
 ) -> list[dict]:
     """Retrieve subscription update counts grouped by agent and period."""
-    await _flush_pending_subscription_updates()
     trunc_expr = _build_trunc_expression(db, period, UserSubscriptionUpdate.created_at, start)
     start_utc = get_complete_period_start_for_filter(start, period)
     end_utc = to_utc_for_filter(end)
@@ -1470,7 +1477,8 @@ async def get_users_subscription_agent_stats(
         .order_by(trunc_expr)
     )
 
-    result = await db.execute(stmt)
+    async with _subscription_update_read_session(db) as read_db:
+        result = await read_db.execute(stmt)
     dialect = db.bind.dialect.name
     rows = []
     for row in result.mappings():

--- a/tests/api/test_subscription_update_snapshot.py
+++ b/tests/api/test_subscription_update_snapshot.py
@@ -1,0 +1,64 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import delete, select
+
+from app.db.crud.user import (
+    get_users_sub_update_list,
+    get_users_subscription_agent_counts,
+    get_users_subscription_agent_stats,
+)
+from app.db.models import User, UserSubscriptionUpdate
+from app.models.stats import Period
+from app.subscription import sub_update_buffer
+from tests.api import TestSession, engine
+from tests.api.helpers import unique_name
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reader", ["list", "counts", "stats"])
+@pytest.mark.parametrize("already_flushed", [False, True])
+async def test_subscription_reads_see_updates_after_request_snapshot(reader, already_flushed):
+    async with TestSession() as setup:
+        user = User(username=unique_name("sub_snapshot"))
+        setup.add(user)
+        await setup.commit()
+        user_id = user.id
+
+    try:
+        async with TestSession() as request:
+            if engine.dialect.name in {"mysql", "mariadb", "postgresql"}:
+                await request.connection(execution_options={"isolation_level": "REPEATABLE READ"})
+            # Authorization/user lookup establishes the request's read snapshot.
+            db_user = await request.scalar(select(User).where(User.id == user_id))
+            db_user.note = "uncommitted caller change"
+            await sub_update_buffer.queue_user_sub_update(user_id, "snapshot-client")
+            if already_flushed:
+                await sub_update_buffer.flush_user_sub_updates()
+
+            start = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)
+            end = start + timedelta(hours=3)
+            if reader == "list":
+                rows, count = await get_users_sub_update_list(request, user_id)
+                assert count == 1
+                assert [row.user_agent for row in rows] == ["snapshot-client"]
+            elif reader == "counts":
+                counts = await get_users_subscription_agent_counts(request, user_id=user_id, start=start, end=end)
+                assert counts == [("snapshot-client", 1)]
+            else:
+                stats = await get_users_subscription_agent_stats(request, start, end, Period.hour, user_id=user_id)
+                assert [(row["agent"], row["count"]) for row in stats] == [("snapshot-client", 1)]
+
+            assert request.in_transaction()
+            assert db_user in request.dirty
+            assert db_user.note == "uncommitted caller change"
+
+        async with TestSession() as check:
+            assert await check.scalar(select(User.note).where(User.id == user_id)) is None
+    finally:
+        await sub_update_buffer.flush_user_sub_updates()
+        async with TestSession() as cleanup:
+            # The API SQLite test engine does not enable foreign-key cascades.
+            await cleanup.execute(delete(UserSubscriptionUpdate).where(UserSubscriptionUpdate.user_id == user_id))
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()


### PR DESCRIPTION
﻿## Summary

After a subscription request queues an update, MySQL and MariaDB subscription history endpoints can return an empty list even though the buffer has been flushed successfully. Authorization/user lookup has already established the request transaction's REPEATABLE READ snapshot, so it cannot see the flush committed by another session.

Read subscription history, agent counts, and chart statistics through a fresh session after flushing. This preserves the caller's transaction and pending changes, keeps pagination/count queries together, and also handles updates flushed before the read helper is called.

Follow-up to #886; fixes the two remaining failures in https://github.com/PasarGuard/panel/actions/runs/34364940294.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed. (Not needed.)
- [x] I checked database migrations when models or schema changed. (No schema changes; MySQL/MariaDB migration checks passed.)
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

- Reproduced both failing CI tests and six new snapshot regressions on MariaDB before the fix: 8 failed. The same cases passed after the fix.
- Full suite on MySQL (Linux, Python 3.14): 601 passed, 2 skipped.
- Full suite on MariaDB 10.6 (Linux, Python 3.14, NATS, two workers, all-in-one role): 601 passed, 2 skipped.
- Full suite on SQLite (Windows, Python 3.14): 601 passed, 2 skipped.
- Focused PostgreSQL 17 tests: 15 passed, covering six REPEATABLE READ cases, both affected API tests, and buffer regressions.
- Alembic upgrades passed on all four engines; `alembic check` passed on MySQL and MariaDB.
- Ruff lint/format checks and `git diff --check` passed.

The six regression cases cover history, agent counts, and time-bucketed stats with pending and already-flushed updates. They also verify that the caller's pending changes remain uncommitted.

## Screenshots

Not applicable.

## Notes for reviewers

Targets `pref-boost`. No changes to the global isolation level, schema, API response shape, or subscription write buffering. Subscription analytics use a separate database session for committed data; the request's original transaction remains untouched.
