### PR TITLE
test(hosts): use a valid FinalMask noise fixture

### DIFF
--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -344,7 +344,13 @@ def test_host_finalmask_new_types(access_token):
                 "type": "noise",
                 "settings": {
                     "reset": "30-60",
-                    "noise": [{"type": "rand", "rand": "1-8192", "delay": "10-20"}],
+                    "noise": [
+                        {
+                            "type": "array",
+                            "packet": [1, 2, 255],
+                            "delay": "10-20",
+                        }
+                    ],
                 },
             },
         ],
@@ -389,7 +395,11 @@ def test_host_finalmask_new_types(access_token):
         assert fm["udp"][0]["type"] == "realm"
         assert fm["udp"][1]["type"] == "mkcp-legacy"
         assert fm["udp"][5]["settings"].get("reset") == "30-60"
-        assert "apply_to" not in (fm["udp"][5]["settings"].get("noise") or [{}])[0]
+        noise = (fm["udp"][5]["settings"].get("noise") or [{}])[0]
+        assert noise.get("type") == "array"
+        assert noise.get("packet") == [1, 2, 255]
+        assert noise.get("rand") is None
+        assert "apply_to" not in noise
     finally:
         client.delete(f"/api/host/{host_id}", headers={"Authorization": f"Bearer {access_token}"})
         delete_core(access_token, core["id"])


### PR DESCRIPTION
## Problem

`tests/api/test_host.py::test_host_finalmask_new_types` used `type: "rand"` for a FinalMask noise item. Clean `origin/dev` rejects that fixture with a Pydantic `string_pattern_mismatch`, so the same baseline test fails independently of the feature changes in #758 and #879.

Xray treats FinalMask noise `type` as the packet encoding (`array`, `str`, `hex`, or `base64`). Random padding is configured through the separate `rand` field, and the documented contract says `packet` and `rand` conflict:

- https://github.com/XTLS/Xray-docs-next/blob/main/docs/config/transports/finalmask.md
- https://github.com/XTLS/Xray-core/blob/main/infra/conf/transport_internet.go

## Change

Use a valid `array` packet in the existing API fixture and verify its POST/GET serialization. The assertion also confirms that the serialized item does not acquire a random-padding value or the Freedom-only `apply_to` field.

This is a test-only compatibility correction. The production `FinalMaskNoiseItem` model on `origin/dev` already matches Xray's accepted type values, so no application code or dependencies change.

## Validation

- `python -m pytest -q --tb=short tests/api/test_host.py::test_host_finalmask_new_types` — 1 passed
- direct `FinalMaskNoiseItem` validation — valid array packet accepted; prior `type: "rand"` fixture rejected with `string_pattern_mismatch`
- `python -m ruff check tests/api/test_host.py` — passed
- `python -m ruff format --check tests/api/test_host.py` — passed
- `git diff --check` — passed
