### PR TITLE
perf(nats): optimize user sync and bound queue processing

### DIFF
--- a/app/jobs/cleanup_node_sync.py
+++ b/app/jobs/cleanup_node_sync.py
@@ -1,0 +1,37 @@
+"""Compact completed node-sync work on the scheduler leader only."""
+
+from app import scheduler
+from app.nats import needs_shared_bridge_memory
+from app.nats.client import create_nats_client, get_jetstream_context
+from app.nats.kv_cleanup import compact_deleted_keys
+from app.nats.leader import is_job_leader
+from app.utils.logger import get_logger
+from config import nats_settings, runtime_settings
+
+logger = get_logger("jobs")
+
+
+async def cleanup_node_sync():
+    if not is_job_leader():
+        return
+    nc = await create_nats_client()
+    if nc is None:
+        return
+    try:
+        count = await compact_deleted_keys(await get_jetstream_context(nc), nats_settings.node_user_sync_kv_bucket)
+        if count:
+            logger.info("Compacted %s completed node-sync keys", count)
+    finally:
+        await nc.close()
+
+
+if runtime_settings.role.runs_node and needs_shared_bridge_memory():
+    scheduler.add_job(
+        cleanup_node_sync,
+        "interval",
+        seconds=300,
+        max_instances=1,
+        coalesce=True,
+        id="cleanup_node_sync",
+        replace_existing=True,
+    )

--- a/app/nats/kv_cas.py
+++ b/app/nats/kv_cas.py
@@ -12,6 +12,7 @@ import nats.errors as nats_errors
 import nats.js.errors as nats_js_errors
 from nats.js.kv import KeyValue
 
+from app.nats.kv_watch import watch_kv
 from app.utils.logger import get_logger
 
 logger = get_logger("nats-kv-cas")
@@ -70,12 +71,17 @@ async def kv_cas_json(kv: CasKv, key: str, value: dict[str, Any], revision: int)
         return False
 
 
-async def kv_put_json(kv: CasKv, key: str, value: dict[str, Any]) -> None:
+async def kv_put_json(kv: CasKv, key: str, value: dict[str, Any]) -> int:
     """Upsert JSON with CAS retries (latest value wins)."""
+    payload = json.dumps(value, separators=(",", ":")).encode()
     for attempt in range(32):
         _, rev = await kv_get_json(kv, key)
-        if await kv_cas_json(kv, key, value, rev):
-            return
+        try:
+            if rev == 0:
+                return await kv.create(key, payload)
+            return await kv.update(key, payload, last=rev)
+        except nats_errors.Error as exc:
+            logger.debug("NATS KV put attempt failed for key=%s revision=%s: %s", key, rev, exc)
         if attempt < 31:
             await cas_retry_backoff()
     raise RuntimeError(f"failed to put NATS KV key={key} after CAS retries")
@@ -91,7 +97,7 @@ async def kv_list_keys(kv: CasKv, prefix: str) -> list[str]:
     # filter subject, so use that to filter server-side to this prefix only.
     watch = getattr(kv, "watch", None)
     if callable(watch):
-        watcher = await watch(f"{prefix}*", ignore_deletes=True, meta_only=True)
+        watcher = await watch_kv(kv, f"{prefix}*", ignore_deletes=True, inactive_threshold=5, snapshot_only=True)
         try:
             keys: list[str] = []
             async for entry in watcher:

--- a/app/nats/kv_cleanup.py
+++ b/app/nats/kv_cleanup.py
@@ -1,0 +1,35 @@
+"""Remove old queue tombstones without deleting concurrently recreated keys."""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime
+
+from nats.js.client import JetStreamContext
+from nats.js.errors import BucketNotFoundError
+
+from app.nats.kv_watch import watch_kv
+
+
+async def compact_deleted_keys(js: JetStreamContext, bucket: str, *, older_than: float = 300) -> int:
+    try:
+        kv = await js.key_value(bucket)
+    except BucketNotFoundError:
+        return 0
+    watcher = await watch_kv(kv, ">", inactive_threshold=5, snapshot_only=True)
+    cutoff = datetime.now(UTC).timestamp() - older_than
+    purged = 0
+    try:
+        async for entry in watcher:
+            if entry is None:
+                break
+            if entry.operation not in ("DEL", "PURGE") or entry.created.timestamp() > cutoff:
+                continue
+            # A key can be recreated after this snapshot. Purge ONLY revisions
+            # up to the observed tombstone, never the newer pending update.
+            await js.purge_stream(f"KV_{bucket}", subject=f"$KV.{bucket}.{entry.key}", seq=entry.revision + 1)
+            purged += 1
+    finally:
+        with contextlib.suppress(Exception):
+            await watcher.stop()
+    return purged

--- a/app/nats/kv_index.py
+++ b/app/nats/kv_index.py
@@ -1,0 +1,140 @@
+"""A live key-only index for the shared node sync queue.
+
+KV values and CAS revisions still come from JetStream. The index only discovers
+candidate keys, so a delayed notification cannot grant ownership of a user.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+from app.nats.kv_cas import CasKv, kv_list_keys
+from app.nats.kv_watch import watch_kv
+from app.utils.logger import get_logger
+
+logger = get_logger("nats-kv-index")
+
+
+class KvKeyIndex:
+    SNAPSHOT_STALL_TIMEOUT = 30
+
+    def __init__(self, kv: CasKv):
+        self._kv = kv
+        self._keys: dict[str, dict[str, int]] = {}
+        self._local_puts: dict[str, int] = {}
+        self._last_revision = 0
+        self._ready = asyncio.Event()
+        self._task: asyncio.Task | None = None
+        self._closed = False
+
+    async def entries(self, prefix: str) -> dict[str, int]:
+        if self._closed:
+            raise RuntimeError("NATS key index is closed")
+        if not callable(getattr(self._kv, "watch", None)):
+            return dict.fromkeys(await kv_list_keys(self._kv, prefix), 0)
+        if self._task is None:
+            # No await between checking and setting: all node callers share one
+            # watcher per process, including concurrent first-time callers.
+            self._task = asyncio.create_task(self._run(), name="node-sync-key-index")
+        while not self._ready.is_set():
+            revision = self._last_revision
+            try:
+                async with asyncio.timeout(self.SNAPSHOT_STALL_TIMEOUT):
+                    await self._ready.wait()
+            except TimeoutError:
+                # Large snapshots can take longer than one timeout interval.
+                # Fail only when replay has stopped making progress.
+                if self._last_revision <= revision:
+                    raise
+        if self._closed:
+            raise RuntimeError("NATS key index is closed")
+        return dict(self._keys.get(prefix, {}))
+
+    async def keys(self, prefix: str) -> list[str]:
+        return list(await self.entries(prefix))
+
+    async def snapshot(self, prefixes: tuple[str, ...]) -> tuple[set[str], int]:
+        """Copy candidate keys and their replay checkpoint without yielding."""
+        await self.entries(prefixes[0])
+        return {key for prefix in prefixes for key in self._keys.get(prefix, {})}, self._last_revision
+
+    def observe_put(self, key: str, revision: int) -> None:
+        """Expose an acknowledged local write before its watch event arrives.
+
+        The bridge can exit its lazy sync loop on an empty claim, so local
+        enqueue/requeue must be immediately discoverable. Ignore old watch
+        events until they catch up with this write's revision.
+        """
+        if (
+            self._closed
+            or not callable(getattr(self._kv, "watch", None))
+            or revision <= max(self._last_revision, self._local_puts.get(key, 0))
+        ):
+            return
+        self._local_puts[key] = revision
+        self._keys.setdefault(key.rpartition(".")[0] + ".", {})[key] = revision
+
+    def discard(self, key: str, revision: int) -> None:
+        """Evict a stale candidate only if a newer event has not replaced it."""
+        prefix = key.rpartition(".")[0] + "."
+        keys = self._keys.get(prefix)
+        if keys is not None and keys.get(key) == revision:
+            del keys[key]
+            if not keys:
+                del self._keys[prefix]
+
+    async def _run(self) -> None:
+        retry_delay = 0.5
+        while not self._closed:
+            watcher = None
+            self._ready.clear()
+            self._keys.clear()
+            self._local_puts.clear()
+            self._last_revision = 0
+            try:
+                # Replay once, then consume changes. Do not ignore deletes:
+                # removing them from the index bounds memory by live work.
+                watcher = await watch_kv(self._kv, ">", inactive_threshold=30)
+                async for entry in watcher:
+                    if entry is None:
+                        self._ready.set()
+                        retry_delay = 0.5
+                        continue
+                    self._last_revision = max(self._last_revision, entry.revision)
+                    if self._local_puts.get(entry.key, 0) > entry.revision:
+                        continue
+                    self._local_puts.pop(entry.key, None)
+                    prefix, _, _ = entry.key.rpartition(".")
+                    prefix += "."
+                    if entry.operation in ("DEL", "PURGE"):
+                        keys = self._keys.get(prefix)
+                        if keys is not None:
+                            keys.pop(entry.key, None)
+                            if not keys:
+                                del self._keys[prefix]
+                    else:
+                        self._keys.setdefault(prefix, {})[entry.key] = entry.revision
+                if not self._closed:
+                    raise RuntimeError("NATS key watcher stopped")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("Node sync key index interrupted; rebuilding after backoff", exc_info=True)
+            finally:
+                self._ready.clear()
+                if watcher is not None:
+                    with contextlib.suppress(Exception):
+                        await watcher.stop()
+            await asyncio.sleep(retry_delay)
+            retry_delay = min(retry_delay * 2, 30)
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        self._keys.clear()
+        self._local_puts.clear()
+        self._ready.set()

--- a/app/nats/kv_watch.py
+++ b/app/nats/kv_watch.py
@@ -1,0 +1,159 @@
+"""Bounded KV snapshots followed by ordered live updates."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy
+from nats.js.kv import KV_DEL, KV_MARKER_REASON, KV_OP, KV_PURGE, KeyValue
+
+
+async def watch_kv(
+    kv, pattern: str, *, ignore_deletes=False, inactive_threshold=30, snapshot_only=False, start_revision=None
+):
+    if not isinstance(kv, KeyValue):
+        return await kv.watch(
+            pattern, ignore_deletes=ignore_deletes, meta_only=True, inactive_threshold=inactive_threshold
+        )
+    return KvWatcher(kv, pattern, ignore_deletes, inactive_threshold, snapshot_only, start_revision)
+
+
+class KvWatcher:
+    """Pull snapshots in batches so slow readers cannot overflow subscriptions.
+
+    A live ordered subscription resumes after the snapshot's last revision.
+    Snapshot consumers are deleted immediately, including on cancellation.
+    """
+
+    BATCH_SIZE = 256
+
+    def __init__(self, kv, pattern, ignore_deletes, inactive_threshold, snapshot_only, start_revision):
+        self._kv = kv
+        self._pattern = pattern
+        self._ignore_deletes = ignore_deletes
+        self._inactive_threshold = inactive_threshold
+        self._snapshot_only = snapshot_only
+        self._start_revision = start_revision
+        # The KV API does not expose a bounded snapshot operation. Keep its
+        # underlying JetStream connection and subject access in this adapter.
+        self._js = kv._js
+        self._stream = kv._stream
+        self._subject = kv._pre + pattern
+        self._snapshot = None
+        self._live = None
+        self._updates = asyncio.Queue(maxsize=self.BATCH_SIZE)
+        self._iterator = self._iterate()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._iterator.__anext__()
+
+    def _entry(self, msg):
+        operation = None
+        if msg.headers:
+            operation = msg.headers.get(KV_OP)
+            if operation is None and KV_MARKER_REASON in msg.headers:
+                reason = msg.headers[KV_MARKER_REASON]
+                if reason in ("MaxAge", "Purge"):
+                    operation = KV_PURGE
+                elif reason == "Remove":
+                    operation = KV_DEL
+                else:
+                    return None
+        if self._ignore_deletes and operation in (KV_DEL, KV_PURGE):
+            return None
+        meta = msg.metadata
+        return KeyValue.Entry(
+            bucket=self._kv._name,
+            key=msg.subject[len(self._kv._pre) :],
+            value=b"",
+            revision=meta.sequence.stream,
+            delta=meta.num_pending,
+            created=meta.timestamp,
+            operation=operation,
+        )
+
+    async def _close_subscription(self, subscription):
+        if subscription is not None:
+            with contextlib.suppress(Exception):
+                await subscription.unsubscribe()
+            with contextlib.suppress(Exception):
+                await self._js.delete_consumer(self._stream, subscription._consumer)
+
+    async def _iterate(self):
+        nc = self._js._nc
+        reconnects = nc.stats["reconnects"]
+        try:
+            watermark = 0 if self._snapshot_only else (await self._js.stream_info(self._stream)).state.last_seq
+            self._snapshot = await self._js.pull_subscribe(
+                self._subject,
+                stream=self._stream,
+                config=ConsumerConfig(
+                    deliver_policy=(
+                        DeliverPolicy.BY_START_SEQUENCE
+                        if self._start_revision is not None
+                        else DeliverPolicy.LAST_PER_SUBJECT
+                    ),
+                    opt_start_seq=self._start_revision,
+                    ack_policy=AckPolicy.NONE,
+                    headers_only=True,
+                    inactive_threshold=max(self._inactive_threshold, 60),
+                ),
+                pending_msgs_limit=self.BATCH_SIZE * 2,
+                pending_bytes_limit=1024 * 1024,
+            )
+            pending = (await self._snapshot.consumer_info()).num_pending
+            while pending:
+                try:
+                    messages = await self._snapshot.fetch(min(self.BATCH_SIZE, pending), timeout=5)
+                except TimeoutError:
+                    messages = []
+                # An interrupted snapshot must be rebuilt: an AckNone consumer
+                # may have advanced while its client was disconnected.
+                if not nc.is_connected or nc.stats["reconnects"] != reconnects:
+                    raise RuntimeError("NATS connection changed during KV snapshot")
+                for msg in messages:
+                    if not self._snapshot_only:
+                        watermark = max(watermark, msg.metadata.sequence.stream)
+                    entry = self._entry(msg)
+                    if entry is not None:
+                        yield entry
+                if messages:
+                    pending = messages[-1].metadata.num_pending
+                else:
+                    pending = (await self._snapshot.consumer_info()).num_pending
+            if not nc.is_connected or nc.stats["reconnects"] != reconnects:
+                raise RuntimeError("NATS connection changed during KV snapshot")
+            await self._close_subscription(self._snapshot)
+            self._snapshot = None
+            if self._snapshot_only:
+                yield None
+                return
+
+            async def receive(msg):
+                entry = self._entry(msg)
+                if entry is not None:
+                    await self._updates.put(entry)
+
+            self._live = await self._js.subscribe(
+                self._subject,
+                stream=self._stream,
+                config=ConsumerConfig(opt_start_seq=watermark + 1),
+                deliver_policy=DeliverPolicy.BY_START_SEQUENCE,
+                ordered_consumer=True,
+                headers_only=True,
+                inactive_threshold=self._inactive_threshold,
+                cb=receive,
+            )
+            yield None
+            while True:
+                yield await self._updates.get()
+        finally:
+            await self._close_subscription(self._snapshot)
+            await self._close_subscription(self._live)
+
+    async def stop(self):
+        await self._iterator.aclose()

--- a/app/node/nats_memory.py
+++ b/app/node/nats_memory.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import time
+from itertools import islice
 from typing import Any
 from uuid import uuid4
 
@@ -27,6 +28,8 @@ from PasarGuardNodeBridge.storage import (
 from app.nats import needs_shared_bridge_memory
 from app.nats.client import create_nats_client, get_jetstream_context, get_or_create_kv_bucket
 from app.nats.kv_cas import CasKv, cas_retry_backoff, kv_cas_json, kv_get_json, kv_list_keys, kv_put_json
+from app.nats.kv_index import KvKeyIndex
+from app.nats.kv_watch import watch_kv
 from app.utils.logger import get_logger
 from config import nats_settings
 
@@ -96,6 +99,24 @@ class NatsUserSyncStore:
 
     def __init__(self, kv: CasKv):
         self._kv = kv
+        self._key_index = KvKeyIndex(kv)
+        self._write_slots = asyncio.Semaphore(32)
+
+    async def close(self) -> None:
+        await self._key_index.close()
+
+    async def _run_bounded(self, operation, items) -> None:
+        async def run(item):
+            async with self._write_slots:
+                await operation(item)
+
+        items = iter(items)
+        while batch := list(islice(items, 32)):
+            # Bound both live tasks and concurrent KV operations during full syncs.
+            results = await asyncio.gather(*(run(item) for item in batch), return_exceptions=True)
+            for result in results:
+                if isinstance(result, BaseException):
+                    raise result
 
     def _pending_prefix(self, node_id: str) -> str:
         return f"p.{node_id}."
@@ -120,20 +141,22 @@ class NatsUserSyncStore:
         key = self._pending_key(node_id, email)
         value = {"email": email, "user": _b64_user(user)}
         self._ensure_value_size(key, value)
-        await kv_put_json(self._kv, key, value)
+        revision = await kv_put_json(self._kv, key, value)
+        self._key_index.observe_put(key, revision)
 
     async def enqueue_users(self, node_id: str, users: list[User]) -> None:
         if not users:
             return
         # Latest payload per email wins (dedupe across the batch first).
         by_email = {user.email: user for user in users}
-        await asyncio.gather(*(self._enqueue_one(node_id, email, user) for email, user in by_email.items()))
+        await self._run_bounded(lambda user: self._enqueue_one(node_id, user.email, user), by_email.values())
 
     async def _requeue_expired_claims(self, node_id: str) -> None:
         now = time.time()
-        for key in await kv_list_keys(self._kv, self._claimed_prefix(node_id)):
+        for key, indexed_revision in (await self._key_index.entries(self._claimed_prefix(node_id))).items():
             doc, rev = await kv_get_json(self._kv, key)
             if doc is None:
+                self._key_index.discard(key, indexed_revision)
                 continue
             if float(doc.get("expires_at", 0)) > now:
                 continue
@@ -142,7 +165,8 @@ class NatsUserSyncStore:
             if isinstance(email, str) and isinstance(user_b64, str):
                 pending_key = self._pending_key(node_id, email)
                 pending_value = {"email": email, "user": user_b64}
-                await kv_put_json(self._kv, pending_key, pending_value)
+                revision = await kv_put_json(self._kv, pending_key, pending_value)
+                self._key_index.observe_put(pending_key, revision)
             try:
                 await self._kv.delete(key, last=rev)
             except Exception as exc:
@@ -155,11 +179,12 @@ class NatsUserSyncStore:
 
         result: list[ClaimedUser] = []
         now = time.time()
-        for pending_key in await kv_list_keys(self._kv, self._pending_prefix(node_id)):
+        for pending_key, indexed_revision in (await self._key_index.entries(self._pending_prefix(node_id))).items():
             if len(result) >= limit:
                 break
             doc, rev = await kv_get_json(self._kv, pending_key)
             if doc is None:
+                self._key_index.discard(pending_key, indexed_revision)
                 continue
             email = doc.get("email")
             user_b64 = doc.get("user")
@@ -177,8 +202,14 @@ class NatsUserSyncStore:
             self._ensure_value_size(claimed_key, claimed_value)
             try:
                 # Create-only so two workers cannot claim into the same token key.
-                if not await kv_cas_json(self._kv, claimed_key, claimed_value, 0):
+                try:
+                    claimed_revision = await self._kv.create(
+                        claimed_key, json.dumps(claimed_value, separators=(",", ":")).encode()
+                    )
+                except nats.errors.Error as exc:
+                    logger.debug("Failed to create claim key=%s: %s", claimed_key, exc)
                     continue
+                self._key_index.observe_put(claimed_key, claimed_revision)
                 await self._kv.delete(pending_key, last=rev)
             except Exception as exc:
                 logger.debug("Claim race for pending key=%s: %s", pending_key, exc)
@@ -207,13 +238,14 @@ class NatsUserSyncStore:
     async def ack_users(self, node_id: str, tokens: list[str]) -> None:
         if not tokens:
             return
-        await asyncio.gather(*(self._ack_one(node_id, token) for token in tokens))
+        await self._run_bounded(lambda token: self._ack_one(node_id, token), tokens)
 
     async def _requeue_one(self, node_id: str, item: ClaimedUser) -> None:
         pending_key = self._pending_key(node_id, item.user.email)
         pending_value = {"email": item.user.email, "user": _b64_user(item.user)}
         self._ensure_value_size(pending_key, pending_value)
-        await kv_put_json(self._kv, pending_key, pending_value)
+        revision = await kv_put_json(self._kv, pending_key, pending_value)
+        self._key_index.observe_put(pending_key, revision)
         claimed_key = self._claimed_key(node_id, item.token)
         doc, rev = await kv_get_json(self._kv, claimed_key)
         if doc is None:
@@ -226,7 +258,7 @@ class NatsUserSyncStore:
     async def requeue_users(self, node_id: str, claimed_users: list[ClaimedUser]) -> None:
         if not claimed_users:
             return
-        await asyncio.gather(*(self._requeue_one(node_id, item) for item in claimed_users))
+        await self._run_bounded(lambda item: self._requeue_one(node_id, item), claimed_users)
 
     async def _clear_one(self, key: str) -> None:
         doc, rev = await kv_get_json(self._kv, key)
@@ -238,9 +270,26 @@ class NatsUserSyncStore:
             logger.debug("Failed to clear key=%s: %s", key, exc)
 
     async def clear(self, node_id: str) -> None:
-        pending_keys = await kv_list_keys(self._kv, self._pending_prefix(node_id))
-        claimed_keys = await kv_list_keys(self._kv, self._claimed_prefix(node_id))
-        await asyncio.gather(*(self._clear_one(key) for key in [*pending_keys, *claimed_keys]))
+        prefixes = (self._pending_prefix(node_id), self._claimed_prefix(node_id))
+        if isinstance(self._kv, KeyValue):
+            keys, revision = await self._key_index.snapshot(prefixes)
+            # Include acknowledged writes from other workers even if their live
+            # notifications are delayed. Replaying only the tail avoids reading
+            # the node's entire deletion history on every reconnect.
+            watcher = await watch_kv(
+                self._kv, f"*.{node_id}.*", ignore_deletes=True, snapshot_only=True, start_revision=revision + 1
+            )
+            try:
+                async for entry in watcher:
+                    if entry is None:
+                        break
+                    if entry.key.startswith(prefixes):
+                        keys.add(entry.key)
+            finally:
+                await watcher.stop()
+        else:
+            keys = set(await kv_list_keys(self._kv, prefixes[0])) | set(await kv_list_keys(self._kv, prefixes[1]))
+        await self._run_bounded(self._clear_one, keys)
 
 
 class NatsNodeLifecycleCoordinator:
@@ -445,6 +494,8 @@ def get_bridge_memory() -> tuple[NatsUserSyncStore | None, NatsNodeLifecycleCoor
 
 async def shutdown_bridge_memory() -> None:
     global _nc, _user_sync_kv, _lifecycle_kv, _user_sync_store, _lifecycle_coordinator
+    if _user_sync_store is not None:
+        await _user_sync_store.close()
     if _nc is not None:
         await _nc.close()
     _nc = None

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 
 from alembic.command import upgrade
 from alembic.config import Config
@@ -78,9 +79,20 @@ def run_migrations_sync():
         alembic_cfg = Config("alembic.ini")
         alembic_cfg.set_main_option("sqlalchemy.url", sync_db_url)
 
-        with create_engine(sync_db_url).begin() as connection:
-            alembic_cfg.attributes["connection"] = connection
-            upgrade(alembic_cfg, "head")
+        # Alembic's fileConfig disables pre-existing application loggers. Keep
+        # migration setup from making later log assertions depend on test order.
+        logger_states = {
+            logger: logger.disabled
+            for logger in logging.root.manager.loggerDict.values()
+            if isinstance(logger, logging.Logger)
+        }
+        try:
+            with create_engine(sync_db_url).begin() as connection:
+                alembic_cfg.attributes["connection"] = connection
+                upgrade(alembic_cfg, "head")
+        finally:
+            for logger, disabled in logger_states.items():
+                logger.disabled = disabled
         print("[migrations] Migrations completed successfully")
         return True  # Migrations ran successfully
     except Exception as e:

--- a/tests/nats_sync_process_worker.py
+++ b/tests/nats_sync_process_worker.py
@@ -1,0 +1,40 @@
+"""Independent Python worker used by the real NATS integration tests."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import nats
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.node.nats_memory import NatsUserSyncStore
+
+
+async def main():
+    url, bucket, worker_id, node_count = sys.argv[1:]
+    nc = await nats.connect(url)
+    store = NatsUserSyncStore(await nc.jetstream().key_value(bucket))
+    emails = []
+    try:
+        async with asyncio.timeout(60):
+            # All inputs are seeded before process startup. An empty complete
+            # pass means remaining work belongs to one of the other processes.
+            while True:
+                progress = False
+                for node in range(int(node_count)):
+                    claimed = await store.claim_users(str(node), worker_id, 50, 120)
+                    emails.extend(item.user.email for item in claimed)
+                    await store.ack_users(str(node), [item.token for item in claimed])
+                    progress |= bool(claimed)
+                if not progress:
+                    break
+        print(json.dumps(emails), flush=True)
+    finally:
+        await store.close()
+        await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_nats_kv_index.py
+++ b/tests/test_nats_kv_index.py
@@ -1,0 +1,194 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.nats.kv_index import KvKeyIndex
+
+
+class Watcher:
+    def __init__(self, entries=()):
+        self.queue = asyncio.Queue()
+        for entry in entries:
+            self.queue.put_nowait(entry)
+        self.stopped = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        entry = await self.queue.get()
+        if isinstance(entry, Exception):
+            raise entry
+        return entry
+
+    async def stop(self):
+        self.stopped = True
+
+
+def entry(key, revision=1, operation=None):
+    return SimpleNamespace(key=key, revision=revision, operation=operation)
+
+
+class WatchedKv:
+    def __init__(self, *watchers):
+        self.watchers = iter(watchers)
+        self.calls = 0
+
+    async def watch(self, subject, **kwargs):
+        assert subject == ">"
+        assert kwargs["meta_only"] is True
+        assert not kwargs.get("ignore_deletes")
+        self.calls += 1
+        return next(self.watchers)
+
+
+async def eventually(predicate):
+    async with asyncio.timeout(3):
+        while not predicate():
+            await asyncio.sleep(0.001)
+
+
+async def test_many_nodes_and_concurrent_empty_polls_share_one_watcher():
+    kv = WatchedKv(Watcher([None]))
+    index = KvKeyIndex(kv)
+    try:
+        assert await asyncio.gather(*(index.keys(f"p.{node}.") for node in range(1000))) == [[]] * 1000
+        assert kv.calls == 1
+        assert index._keys == {}
+    finally:
+        await index.close()
+
+
+async def test_initial_snapshot_is_complete_before_exposing_keys():
+    watcher = Watcher([entry("p.1.a"), entry("p.2.b")])
+    index = KvKeyIndex(WatchedKv(watcher))
+    task = asyncio.create_task(index.keys("p.1."))
+    try:
+        await eventually(lambda: "p.2." in index._keys)
+        assert not task.done()
+        watcher.queue.put_nowait(None)
+        assert await task == ["p.1.a"]
+        assert await index.keys("p.2.") == ["p.2.b"]
+    finally:
+        await index.close()
+
+
+async def test_slow_snapshot_can_finish_while_replay_keeps_progressing(monkeypatch):
+    monkeypatch.setattr(KvKeyIndex, "SNAPSHOT_STALL_TIMEOUT", 0.1)
+    watcher = Watcher()
+    index = KvKeyIndex(WatchedKv(watcher))
+    pending = asyncio.create_task(index.keys("p.1."))
+    try:
+        for revision in range(1, 13):
+            watcher.queue.put_nowait(entry("p.1.a", revision))
+            await asyncio.sleep(0.02)
+        assert not pending.done()
+        watcher.queue.put_nowait(None)
+        assert await pending == ["p.1.a"]
+    finally:
+        await index.close()
+
+
+async def test_stalled_snapshot_still_times_out(monkeypatch):
+    monkeypatch.setattr(KvKeyIndex, "SNAPSHOT_STALL_TIMEOUT", 0.05)
+    index = KvKeyIndex(WatchedKv(Watcher()))
+    try:
+        with pytest.raises(TimeoutError):
+            await index.keys("p.1.")
+    finally:
+        await index.close()
+
+
+async def test_changes_remove_deleted_keys_and_empty_node_indexes():
+    watcher = Watcher([entry("p.1.a"), None])
+    index = KvKeyIndex(WatchedKv(watcher))
+    try:
+        assert await index.keys("p.1.") == ["p.1.a"]
+        for number in range(1000):
+            watcher.queue.put_nowait(entry(f"c.1.{number}", number + 2))
+            watcher.queue.put_nowait(entry(f"c.1.{number}", number + 3, "DEL"))
+        watcher.queue.put_nowait(entry("p.1.a", 3000, "PURGE"))
+        await eventually(lambda: watcher.queue.empty())
+        assert index._keys == {}
+    finally:
+        await index.close()
+    assert watcher.stopped
+
+
+async def test_watch_failure_rebuilds_snapshot_without_stale_keys():
+    first = Watcher([entry("p.1.old"), None])
+    second = Watcher([entry("p.1.new", 2), None])
+    kv = WatchedKv(first, second)
+    index = KvKeyIndex(kv)
+    try:
+        assert await index.keys("p.1.") == ["p.1.old"]
+        first.queue.put_nowait(RuntimeError("connection lost"))
+        await eventually(lambda: first.stopped)
+        assert not index._ready.is_set()
+        assert await index.keys("p.1.") == ["p.1.new"]
+        assert kv.calls == 2
+    finally:
+        await index.close()
+
+
+async def test_cancelled_caller_does_not_cancel_shared_initialization():
+    watcher = Watcher()
+    index = KvKeyIndex(WatchedKv(watcher))
+    cancelled = asyncio.create_task(index.keys("p.1."))
+    remaining = asyncio.create_task(index.keys("p.2."))
+    try:
+        await asyncio.sleep(0)
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        watcher.queue.put_nowait(entry("p.2.a"))
+        watcher.queue.put_nowait(None)
+        assert await remaining == ["p.2.a"]
+    finally:
+        await index.close()
+
+
+async def test_close_wakes_waiters_and_rejects_future_reads():
+    index = KvKeyIndex(WatchedKv(Watcher()))
+    pending = asyncio.create_task(index.keys("p.1."))
+    await asyncio.sleep(0)
+    await index.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        await pending
+    with pytest.raises(RuntimeError, match="closed"):
+        await index.keys("p.1.")
+
+
+async def test_local_writes_are_visible_before_delayed_watch_events():
+    watcher = Watcher([None])
+    index = KvKeyIndex(WatchedKv(watcher))
+    try:
+        assert await index.keys("p.1.") == []
+        index.observe_put("p.1.a", 3)
+        index.observe_put("p.1.a", 1)  # a delayed acknowledgement cannot regress it
+        watcher.queue.put_nowait(entry("p.1.a", 2, "DEL"))
+        await eventually(lambda: watcher.queue.empty())
+        assert await index.entries("p.1.") == {"p.1.a": 3}
+        watcher.queue.put_nowait(entry("p.1.a", 3))
+        await eventually(lambda: watcher.queue.empty())
+        assert index._local_puts == {}
+        watcher.queue.put_nowait(entry("p.1.a", 4, "DEL"))
+        await eventually(lambda: watcher.queue.empty())
+        index.observe_put("p.1.a", 3)  # delete already observed before publish reply
+        assert await index.keys("p.1.") == []
+    finally:
+        await index.close()
+
+
+async def test_missing_candidate_eviction_does_not_remove_a_newer_update():
+    index = KvKeyIndex(WatchedKv(Watcher([entry("p.1.a", 1), None])))
+    try:
+        assert await index.entries("p.1.") == {"p.1.a": 1}
+        index.observe_put("p.1.a", 2)
+        index.discard("p.1.a", 1)
+        assert await index.entries("p.1.") == {"p.1.a": 2}
+        index.discard("p.1.a", 2)
+        assert index._keys == {}
+    finally:
+        await index.close()

--- a/tests/test_nats_node_memory.py
+++ b/tests/test_nats_node_memory.py
@@ -73,6 +73,31 @@ async def test_user_sync_enqueue_shards_per_email_key():
 
 
 @pytest.mark.asyncio
+async def test_bulk_sync_bounds_concurrent_writes_across_nodes():
+    kv = MemoryCasKv()
+    store = NatsUserSyncStore(kv)
+    create = kv.create
+    active = peak = 0
+
+    async def slow_create(key, value):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        try:
+            await asyncio.sleep(0.001)
+            return await create(key, value)
+        finally:
+            active -= 1
+
+    kv.create = slow_create
+    users = [_user(f"user{i}") for i in range(200)]
+    await asyncio.gather(*(store.enqueue_users(str(node), users) for node in range(4)))
+    assert len(kv._data) == 800
+    assert 1 < peak <= 32
+    assert active == 0
+
+
+@pytest.mark.asyncio
 async def test_claim_cleans_up_claimed_key_when_pending_delete_fails():
     kv = MemoryCasKv()
     store = NatsUserSyncStore(kv)

--- a/tests/test_nats_sync_integration.py
+++ b/tests/test_nats_sync_integration.py
@@ -1,0 +1,503 @@
+"""NATS user synchronization integration tests. Set NATS_SERVER_BINARY or install nats-server."""
+
+import asyncio
+import contextlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import nats
+import pytest
+import pytest_asyncio
+from nats.js.errors import KeyNotFoundError
+from PasarGuardNodeBridge.common.service_pb2 import User
+
+from app.nats.kv_cleanup import compact_deleted_keys
+from app.nats.kv_watch import KvWatcher, watch_kv
+from app.node.nats_memory import NatsUserSyncStore
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def jetstream(tmp_path):
+    binary = os.environ.get("NATS_SERVER_BINARY") or shutil.which("nats-server")
+    if not binary:
+        pytest.skip("Set NATS_SERVER_BINARY to run JetStream integration tests")
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    process = await asyncio.to_thread(
+        subprocess.Popen,
+        [binary, "-js", "-a", "127.0.0.1", "-p", str(port), "-sd", str(tmp_path / "nats")],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+    )
+    nc = None
+    try:
+        async with asyncio.timeout(10):
+            while True:
+                try:
+                    _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+                    writer.close()
+                    await writer.wait_closed()
+                    break
+                except OSError:
+                    if process.poll() is not None:
+                        raise RuntimeError("Test NATS server exited during startup")
+                    await asyncio.sleep(0.02)
+        url = f"nats://127.0.0.1:{port}"
+        nc = await nats.connect(url)
+        js = nc.jetstream()
+        bucket = "sync_" + uuid4().hex
+        kv = await js.create_key_value(bucket=bucket)
+
+        async def restart():
+            nonlocal process
+            process.terminate()
+            await asyncio.to_thread(process.wait, timeout=10)
+            process = await asyncio.to_thread(
+                subprocess.Popen,
+                process.args,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+            )
+            async with asyncio.timeout(10):
+                while not nc.is_connected or nc.stats["reconnects"] == 0:
+                    await asyncio.sleep(0.02)
+
+        yield SimpleNamespace(nc=nc, js=js, kv=kv, bucket=bucket, process=process, url=url, restart=restart)
+    finally:
+        if nc is not None:
+            await nc.close()
+        process.terminate()
+        await asyncio.to_thread(process.wait, timeout=10)
+
+
+async def wait_for_keys(store, prefix, count, timeout=10):
+    async with asyncio.timeout(timeout):
+        while len(await store._key_index.keys(prefix)) != count:
+            await asyncio.sleep(0.005)
+
+
+@pytest.mark.parametrize("snapshot_only", [False, True])
+async def test_snapshot_pauses_delivery_until_reader_requests_next_batch(jetstream, monkeypatch, snapshot_only):
+    monkeypatch.setattr(KvWatcher, "BATCH_SIZE", 8)
+    expected = {}
+    for number in range(100):
+        key = f"p.1.{number}"
+        await jetstream.kv.put(key, b"value")
+        expected[key] = "DEL" if number % 2 else None
+        if number % 2:
+            await jetstream.kv.delete(key)
+    watcher = await watch_kv(jetstream.kv, ">", snapshot_only=snapshot_only)
+    try:
+        first = await anext(watcher)
+        delivered = (await watcher._snapshot.consumer_info()).delivered.consumer_seq
+        await asyncio.sleep(0.1)
+        assert (await watcher._snapshot.consumer_info()).delivered.consumer_seq == delivered == 8
+        assert watcher._snapshot.pending_msgs == 0
+        actual = {first.key: first.operation}
+        async for entry in watcher:
+            if entry is None:
+                break
+            assert entry.key not in actual
+            actual[entry.key] = entry.operation
+        assert actual == expected
+        info = await jetstream.js.stream_info(f"KV_{jetstream.bucket}")
+        assert info.state.consumer_count == (0 if snapshot_only else 1)
+    finally:
+        await watcher.stop()
+    assert (await jetstream.js.stream_info(f"KV_{jetstream.bucket}")).state.consumer_count == 0
+
+
+async def test_snapshot_to_live_handoff_preserves_concurrent_changes(jetstream, monkeypatch):
+    await jetstream.kv.put("p.1.existing", b"old")
+    subscribe = jetstream.js.subscribe
+    revisions = {}
+
+    async def write_before_live_subscription(*args, **kwargs):
+        revisions["p.1.existing"] = await jetstream.kv.put("p.1.existing", b"new")
+        revisions["p.1.added"] = await jetstream.kv.put("p.1.added", b"new")
+        await jetstream.kv.delete("p.1.existing")
+        return await subscribe(*args, **kwargs)
+
+    monkeypatch.setattr(jetstream.js, "subscribe", write_before_live_subscription)
+    watcher = await watch_kv(jetstream.kv, ">")
+    try:
+        assert (await anext(watcher)).key == "p.1.existing"
+        assert await anext(watcher) is None
+        async with asyncio.timeout(5):
+            entries = [await anext(watcher) for _ in range(2)]
+        assert [(entry.key, entry.operation) for entry in entries] == [
+            ("p.1.added", None),
+            ("p.1.existing", "DEL"),
+        ]
+        # A history-one bucket retains the final delete instead of the
+        # intermediate put. Both keys' latest state must reach the index.
+        assert entries[0].revision == revisions["p.1.added"]
+        assert entries[1].revision > revisions["p.1.existing"]
+    finally:
+        await watcher.stop()
+
+
+async def test_interrupted_snapshot_is_rejected_and_consumer_is_removed(jetstream, monkeypatch):
+    monkeypatch.setattr(KvWatcher, "BATCH_SIZE", 1)
+    for number in range(3):
+        await jetstream.kv.put(f"p.1.{number}", b"value")
+    nc = await nats.connect(jetstream.url, reconnect_time_wait=0.05)
+    watcher = await watch_kv(await nc.jetstream().key_value(jetstream.bucket), ">")
+    try:
+        await anext(watcher)
+        nc._transport.close()
+        async with asyncio.timeout(5):
+            while nc.stats["reconnects"] == 0:
+                await asyncio.sleep(0.02)
+        with pytest.raises(RuntimeError, match="connection changed during KV snapshot"):
+            await anext(watcher)
+        assert (await jetstream.js.stream_info(f"KV_{jetstream.bucket}")).state.consumer_count == 0
+    finally:
+        await watcher.stop()
+        await nc.close()
+
+
+async def test_stopping_partial_snapshot_removes_consumer(jetstream):
+    for number in range(3):
+        await jetstream.kv.put(f"p.1.{number}", b"value")
+    watcher = await watch_kv(jetstream.kv, ">")
+    await anext(watcher)
+    await watcher.stop()
+    assert (await jetstream.js.stream_info(f"KV_{jetstream.bucket}")).state.consumer_count == 0
+
+
+async def test_idle_polls_do_not_create_consumers_or_send_requests(jetstream):
+    stores = [NatsUserSyncStore(jetstream.kv) for _ in range(4)]
+    try:
+        # Seed deletion markers for completed claims.
+        for number in range(300):
+            await jetstream.kv.put(f"c.{number % 8}.{number}", b"{}")
+            await jetstream.kv.delete(f"c.{number % 8}.{number}")
+        for store in stores:
+            assert await store.claim_users("0", "warmup", 10, 30) == []
+        before = await jetstream.js.stream_info(f"KV_{jetstream.bucket}")
+        sent = jetstream.nc.stats["out_msgs"]
+        for _ in range(20):
+            results = await asyncio.gather(
+                *(
+                    store.claim_users(str(node), str(worker), 10, 30)
+                    for worker, store in enumerate(stores)
+                    for node in range(8)
+                )
+            )
+            assert all(result == [] for result in results)
+        assert jetstream.nc.stats["out_msgs"] == sent
+        after = await jetstream.js.stream_info(f"KV_{jetstream.bucket}")
+        assert before.state.consumer_count == after.state.consumer_count == 4
+        assert all(store._key_index._keys == {} for store in stores)
+    finally:
+        await asyncio.gather(*(store.close() for store in stores))
+
+
+async def test_repeated_clear_does_not_replay_old_deletion_markers(jetstream):
+    for number in range(1000):
+        await jetstream.kv.delete(f"c.1.{number}")
+    store = NatsUserSyncStore(jetstream.kv)
+    try:
+        assert await store._key_index.keys("c.1.") == []
+        received = jetstream.nc.stats["in_msgs"]
+        for _ in range(20):
+            await store.clear("1")
+        assert jetstream.nc.stats["in_msgs"] - received < 400
+        assert (await jetstream.js.stream_info(f"KV_{jetstream.bucket}")).state.consumer_count == 1
+    finally:
+        await store.close()
+
+
+async def test_clear_catches_unobserved_writes_and_preserves_other_nodes(jetstream, monkeypatch):
+    gate = asyncio.Event()
+    gate.set()
+    real_watch = watch_kv
+
+    class DelayedWatcher:
+        def __init__(self, watcher):
+            self.watcher = watcher
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            entry = await anext(self.watcher)
+            if entry is not None:
+                await gate.wait()
+            return entry
+
+        async def stop(self):
+            await self.watcher.stop()
+
+    async def delayed_watch(*args, **kwargs):
+        return DelayedWatcher(await real_watch(*args, **kwargs))
+
+    monkeypatch.setattr("app.nats.kv_index.watch_kv", delayed_watch)
+    kv = jetstream.kv
+    for key in ("p.1.cached", "c.1.cached"):
+        await kv.put(key, b"{}")
+    store = NatsUserSyncStore(kv)
+    try:
+        assert await store._key_index.keys("p.1.") == ["p.1.cached"]
+        gate.clear()
+        for key in ("p.1.new", "c.1.new", "p.2.keep"):
+            await kv.put(key, b"{}")
+        await kv.delete("p.1.cached")
+        await kv.put("p.1.cached", b"{}")
+        await store.enqueue_users("1", [User(email="local")])
+        await store.clear("1")
+        for key in ("p.1.cached", "c.1.cached", "p.1.new", "c.1.new", store._pending_key("1", "local")):
+            with pytest.raises(KeyNotFoundError):
+                await kv.get(key)
+        assert (await kv.get("p.2.keep")).value == b"{}"
+        assert (await jetstream.js.stream_info(f"KV_{jetstream.bucket}")).state.consumer_count == 1
+    finally:
+        await store.close()
+
+
+async def test_concurrent_workers_claim_each_update_once(jetstream):
+    stores = [NatsUserSyncStore(jetstream.kv) for _ in range(4)]
+    users = [User(email=f"user{i}", inbounds=["in"]) for i in range(80)]
+    try:
+        await stores[0].enqueue_users("1", users)
+        await asyncio.gather(*(wait_for_keys(store, "p.1.", 80) for store in stores))
+        batches = await asyncio.gather(
+            *(store.claim_users("1", str(worker), 80, 30) for worker, store in enumerate(stores))
+        )
+        emails = [item.user.email for batch in batches for item in batch]
+        assert len(emails) == len(set(emails)) == 80
+        await asyncio.gather(
+            *(store.ack_users("1", [item.token for item in batch]) for store, batch in zip(stores, batches))
+        )
+        for store in stores:
+            await wait_for_keys(store, "p.1.", 0)
+            await wait_for_keys(store, "c.1.", 0)
+            assert await store.claim_users("1", "idle", 80, 30) == []
+    finally:
+        await asyncio.gather(*(store.close() for store in stores))
+
+
+async def test_live_enqueue_and_expired_claim_recovery(jetstream):
+    first = NatsUserSyncStore(jetstream.kv)
+    second = NatsUserSyncStore(jetstream.kv)
+    try:
+        assert await second.claim_users("1", "other", 10, 30) == []
+        await first.enqueue_users("1", [User(email="recover", inbounds=["in"])])
+        await wait_for_keys(second, "p.1.", 1)
+        claimed = await first.claim_users("1", "crashed", 10, 0)
+        assert len(claimed) == 1
+        await wait_for_keys(second, "p.1.", 0)
+        await wait_for_keys(second, "c.1.", 1)
+        recovered = await second.claim_users("1", "replacement", 10, 30)
+        assert [item.user.email for item in recovered] == ["recover"]
+    finally:
+        await first.close()
+        await second.close()
+
+
+async def test_enqueue_is_claimable_even_when_watch_notifications_are_delayed(jetstream, monkeypatch):
+    gate = asyncio.Event()
+    real_watch = watch_kv
+
+    class DelayedWatcher:
+        def __init__(self, watcher):
+            self.watcher = watcher
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            update = await self.watcher.__anext__()
+            if update is not None:
+                await gate.wait()
+            return update
+
+        async def stop(self):
+            await self.watcher.stop()
+
+    async def delayed_watch(*args, **kwargs):
+        return DelayedWatcher(await real_watch(*args, **kwargs))
+
+    monkeypatch.setattr("app.nats.kv_index.watch_kv", delayed_watch)
+    store = NatsUserSyncStore(jetstream.kv)
+    try:
+        assert await store.claim_users("1", "local", 10, 30) == []
+        await store.enqueue_users("1", [User(email="immediate")])
+        claimed = await store.claim_users("1", "local", 10, 0)
+        assert [item.user.email for item in claimed] == ["immediate"]
+        recovered = await store.claim_users("1", "local", 10, 30)
+        assert [item.user.email for item in recovered] == ["immediate"]
+        assert recovered[0].token != claimed[0].token
+        claimed = recovered
+        await store.requeue_users("1", claimed)
+        assert [item.user.email for item in await store.claim_users("1", "local", 10, 30)] == ["immediate"]
+    finally:
+        await store.close()
+
+
+async def test_compaction_keeps_pending_and_concurrently_recreated_values(jetstream):
+    kv = jetstream.kv
+    await kv.put("p.1.live", b"pending")
+    await kv.put("p.1.race", b"old")
+    await kv.delete("p.1.race")
+    await kv.put("c.1.completed", b"old claim")
+    await kv.delete("c.1.completed")
+    assert await compact_deleted_keys(jetstream.js, jetstream.bucket) == 0  # grace period
+    original_purge = jetstream.js.purge_stream
+
+    async def recreate_before_purge(stream, **kwargs):
+        if kwargs["subject"].endswith("p.1.race"):
+            await kv.put("p.1.race", b"new update")
+        return await original_purge(stream, **kwargs)
+
+    jetstream.js.purge_stream = recreate_before_purge
+    assert await compact_deleted_keys(jetstream.js, jetstream.bucket, older_than=0) == 2
+    assert (await kv.get("p.1.live")).value == b"pending"
+    assert (await kv.get("p.1.race")).value == b"new update"
+    with pytest.raises(KeyNotFoundError):
+        await kv.get("c.1.completed")
+    assert (await jetstream.js.stream_info(f"KV_{jetstream.bucket}")).state.messages == 2
+
+
+async def test_watcher_resumes_after_network_disconnect(jetstream):
+    nc = await nats.connect(jetstream.url, reconnect_time_wait=0.05)
+    store = NatsUserSyncStore(await nc.jetstream().key_value(jetstream.bucket))
+    try:
+        assert await store.claim_users("1", "reader", 10, 30) == []
+        # Drop only this client's TCP transport; the writer remains connected.
+        nc._transport.close()
+        await jetstream.kv.put("p.1.new", b'{"email":"new","user":"CgNuZXc="}')
+        async with asyncio.timeout(10):
+            while nc.stats["reconnects"] == 0:
+                await asyncio.sleep(0.02)
+        await wait_for_keys(store, "p.1.", 1)
+        assert [item.user.email for item in await store.claim_users("1", "reader", 10, 30)] == ["new"]
+    finally:
+        await store.close()
+        with contextlib.suppress(Exception):
+            await nc.close()
+
+
+async def test_four_python_processes_deliver_every_update_once(jetstream):
+    writer = NatsUserSyncStore(jetstream.kv)
+    expected = {f"node{node}-user{user}" for node in range(4) for user in range(250)}
+    for node in range(4):
+        await writer.enqueue_users(str(node), [User(email=f"node{node}-user{user}") for user in range(250)])
+    processes = []
+    try:
+        for worker in range(4):
+            processes.append(
+                await asyncio.create_subprocess_exec(
+                    sys.executable,
+                    str(Path(__file__).with_name("nats_sync_process_worker.py")),
+                    jetstream.url,
+                    jetstream.bucket,
+                    str(worker),
+                    "4",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+                )
+            )
+        async with asyncio.timeout(75):
+            results = await asyncio.gather(*(process.communicate() for process in processes))
+        emails = []
+        for process, (stdout, stderr) in zip(processes, results):
+            assert process.returncode == 0, stderr.decode(errors="replace")
+            emails.extend(json.loads(stdout))
+        assert len(emails) == len(expected)
+        assert set(emails) == expected
+        assert await writer.claim_users("0", "verify", 50, 120) == []
+        await compact_deleted_keys(jetstream.js, jetstream.bucket, older_than=0)
+        assert (await jetstream.js.stream_info(f"KV_{jetstream.bucket}")).state.messages == 0
+    finally:
+        for process in processes:
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
+        await writer.close()
+
+
+async def test_server_restart_preserves_pending_work_and_watch_updates(jetstream):
+    store = NatsUserSyncStore(jetstream.kv)
+    try:
+        await store.enqueue_users("1", [User(email="before-restart")])
+        await wait_for_keys(store, "p.1.", 1)
+        await jetstream.restart()
+        # A separate store writes after reconnect so the reader must receive a
+        # watch notification, rather than using its own immediate-write hint.
+        writer = NatsUserSyncStore(jetstream.kv)
+        try:
+            await writer.enqueue_users("1", [User(email="after-restart")])
+        finally:
+            await writer.close()
+        # nats-py checks heartbeat activity every 10 seconds and the first
+        # check clears the initial active flag. Allow two activity checks.
+        await wait_for_keys(store, "p.1.", 2, timeout=30)
+        claimed = await store.claim_users("1", "restarted", 10, 30)
+        assert {item.user.email for item in claimed} == {"before-restart", "after-restart"}
+        await store.ack_users("1", [item.token for item in claimed])
+        await wait_for_keys(store, "c.1.", 0)
+    finally:
+        await store.close()
+
+
+async def test_repeated_sync_compaction_and_idle_keep_resources_bounded(jetstream):
+    store = NatsUserSyncStore(jetstream.kv)
+    stream = f"KV_{jetstream.bucket}"
+    try:
+        for cycle in range(20):
+            users = [User(email=f"cycle{cycle}-user{number}") for number in range(50)]
+            await store.enqueue_users("1", users)
+            claimed = await store.claim_users("1", "worker", 100, 30)
+            assert {item.user.email for item in claimed} == {user.email for user in users}
+            await store.ack_users("1", [item.token for item in claimed])
+            await wait_for_keys(store, "p.1.", 0)
+            await wait_for_keys(store, "c.1.", 0)
+            assert store._key_index._keys == {}
+            assert store._key_index._local_puts == {}
+            await compact_deleted_keys(jetstream.js, jetstream.bucket, older_than=0)
+            assert (await jetstream.js.stream_info(stream)).state.messages == 0
+
+        sent = jetstream.nc.stats["out_msgs"]
+        # Longer than the live watcher's inactive threshold. It must remain
+        # live while unused, and short-lived compaction consumers must expire.
+        await asyncio.sleep(35)
+        assert await store.claim_users("1", "idle", 100, 30) == []
+        assert jetstream.nc.stats["out_msgs"] == sent
+        assert (await jetstream.js.stream_info(stream)).state.consumer_count == 1
+        await store.enqueue_users("1", [User(email="after-idle")])
+        assert [item.user.email for item in await store.claim_users("1", "worker", 100, 30)] == ["after-idle"]
+    finally:
+        await store.close()
+
+
+async def test_live_index_survives_consumer_recreation(jetstream):
+    store = NatsUserSyncStore(jetstream.kv)
+    try:
+        assert await store.claim_users("1", "reader", 10, 30) == []
+        consumers = await jetstream.js.consumers_info(f"KV_{jetstream.bucket}")
+        assert len(consumers) == 1
+        await jetstream.js.delete_consumer(f"KV_{jetstream.bucket}", consumers[0].name)
+        writer = NatsUserSyncStore(jetstream.kv)
+        try:
+            await writer.enqueue_users("1", [User(email="after-consumer-loss")])
+        finally:
+            await writer.close()
+        async with asyncio.timeout(30):
+            while not await store._key_index.keys("p.1."):
+                await asyncio.sleep(0.05)
+        assert [item.user.email for item in await store.claim_users("1", "reader", 10, 30)] == ["after-consumer-loss"]
+    finally:
+        await store.close()


### PR DESCRIPTION
## Summary

Repeated queue discovery and reconnect cleanup replay historical deletion markers and create JetStream consumers even when little work is pending. Maintain one live key index per worker so initialized idle polls make no NATS requests, and clear node queues using cached candidates plus newer revisions.

- Fetch initial metadata in batches of 256 and hand off to ordered live updates without losing concurrent changes.
- Rebuild interrupted snapshots, allow progressing snapshots to finish, and release consumers on completion, cancellation, and shutdown.
- Bound bulk operations to 32 concurrent requests per store and avoid creating a task for every queued item at once.
- Expose acknowledged local writes and claims immediately so delayed notifications do not delay discovery or expired-claim recovery.
- Compact deletion markers older than five minutes on the scheduler leader, preserving concurrent writes and live work.
- Add regression coverage and restore logger states after test migrations to keep log assertions independent of collection order.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / cleanup
- [ ] Documentation
- [x] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation, translations, or examples if needed. No user-facing configuration changes.
- [x] I checked database migrations when models or schema changed. No schema changes.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

With `DEBUG=false`, `TZ=UTC`, and `NATS_SERVER_BINARY` pointing to NATS 2.10.29:

```sh
python -m pytest tests/test_nats_kv_index.py tests/test_nats_node_memory.py tests/test_nats_sync_integration.py -q
```

- 35 focused tests passed, including four independent worker processes, claim ownership and expiry, delayed notifications, reconnects, server restart, consumer recreation, cancellation, and snapshot-to-live handoff races.
- Full local SQLite suite: 631 passed, zero skipped, with external network tests enabled.
- Local stress validation: 3.5 million deletion markers, four readers, no dropped messages, four steady consumers, and zero outgoing requests from initialized idle polls. Twenty subsequent clears received only 60 control responses without replaying old markers.
- The identical application and test sources passed SQLite, PostgreSQL, TimescaleDB, MySQL, MariaDB, focused NATS tests, lint, and image checks in [CI](https://github.com/DrSaeedHub/panel/actions/runs/34649999386).
- Consolidated source tree matches the validated source tree exactly; `git diff --check` passed.

## Screenshots

Not applicable.

## Notes for reviewers

The index discovers candidate keys only. Authoritative values and claim ownership still use JetStream reads and revision-checked operations. Compaction removes revisions only through an observed deletion marker, protecting concurrently recreated keys.

Bounded snapshots use the KV object's underlying JetStream context because the KV watch API exposes push delivery. Real-server tests cover snapshot lifecycle and ordered live subscription recovery. No database migrations or dependency changes are required.
