### PR TITLE
feat(proxy): add authenticated inbounds in clash/singbox/xray templates

### DIFF
--- a/app/db/migrations/versions/9f3b7c2a1d45_add_general_auth_settings_to_proxy_settings.py
+++ b/app/db/migrations/versions/9f3b7c2a1d45_add_general_auth_settings_to_proxy_settings.py
@@ -1,0 +1,77 @@
+"""add general auth settings to proxy settings
+
+Revision ID: 9f3b7c2a1d45
+Revises: 48a6bcb8bba1
+Create Date: 2026-09-05 12:00:00.000000
+
+"""
+import json
+import secrets
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '9f3b7c2a1d45'
+down_revision = '48a6bcb8bba1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    users_table = sa.table(
+        'users',
+        sa.column('id', sa.Integer),
+        sa.column('proxy_settings', sa.JSON),
+    )
+
+    users = bind.execute(sa.select(users_table.c.id, users_table.c.proxy_settings)).fetchall()
+
+    updates = []
+    for user_id, proxy_settings in users:
+        if isinstance(proxy_settings, str):
+            proxy_settings = json.loads(proxy_settings)
+        if not proxy_settings:
+            proxy_settings = {}
+        if proxy_settings.get('general_auth'):
+            continue
+
+        proxy_settings['general_auth'] = {
+            'username': secrets.token_urlsafe(24),
+            'password': secrets.token_urlsafe(24),
+        }
+        updates.append({'_id': user_id, 'proxy_settings': proxy_settings})
+
+    if updates:
+        bind.execute(
+            users_table.update().where(users_table.c.id == sa.bindparam('_id')),
+            updates,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    users_table = sa.table(
+        'users',
+        sa.column('id', sa.Integer),
+        sa.column('proxy_settings', sa.JSON),
+    )
+
+    users = bind.execute(sa.select(users_table.c.id, users_table.c.proxy_settings)).fetchall()
+
+    updates = []
+    for user_id, proxy_settings in users:
+        if isinstance(proxy_settings, str):
+            proxy_settings = json.loads(proxy_settings)
+        if proxy_settings and 'general_auth' in proxy_settings:
+            proxy_settings.pop('general_auth')
+            updates.append({'_id': user_id, 'proxy_settings': proxy_settings})
+
+    if updates:
+        bind.execute(
+            users_table.update().where(users_table.c.id == sa.bindparam('_id')),
+            updates,
+        )

--- a/app/models/proxy.py
+++ b/app/models/proxy.py
@@ -38,6 +38,13 @@ class HysteriaSettings(BaseModel):
     auth: str = Field(default_factory=random_password, min_length=1)
 
 
+class GeneralAuthSettings(BaseModel):
+    """Stable credentials for local client authentication inbounds."""
+
+    username: str = Field(default_factory=random_password, min_length=1)
+    password: str = Field(default_factory=random_password, min_length=1)
+
+
 class WireGuardPeerIPs(BaseModel):
     peer_ips: list[str] = Field(default_factory=list)
 
@@ -105,6 +112,7 @@ class ProxyTable(BaseModel):
     shadowsocks: ShadowsocksSettings = Field(default_factory=ShadowsocksSettings)
     wireguard: WireGuardSettings = Field(default_factory=WireGuardSettings)
     hysteria: HysteriaSettings = Field(default_factory=HysteriaSettings)
+    general_auth: GeneralAuthSettings = Field(default_factory=GeneralAuthSettings)
 
     def dict(self, *, no_obj=True, **kwargs):
         if no_obj:

--- a/app/subscription/base.py
+++ b/app/subscription/base.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Any, Literal
 from urllib.parse import quote, urlencode
 
+from app.models.proxy import GeneralAuthSettings
 from app.models.subscription import SubscriptionInboundData
 
 
@@ -66,6 +67,7 @@ class BaseSubscription:
         self,
         user_agent_template_content: str | None = None,
         grpc_user_agent_template_content: str | None = None,
+        general_auth: GeneralAuthSettings | None = None,
     ):
         self.proxy_remarks = []
         user_agent_data = json.loads(user_agent_template_content) if user_agent_template_content else {}
@@ -80,6 +82,8 @@ class BaseSubscription:
             self.grpc_user_agent_data = grpc_user_agent_data["list"]
         else:
             self.grpc_user_agent_data = []
+
+        self.general_auth = general_auth
 
         del user_agent_data, grpc_user_agent_data
 

--- a/app/subscription/clash.py
+++ b/app/subscription/clash.py
@@ -2,6 +2,7 @@ from random import choice
 
 from pydantic import BaseModel
 
+from app.models.proxy import GeneralAuthSettings
 from app.models.subscription import (
     GRPCTransportConfig,
     SubscriptionInboundData,
@@ -21,10 +22,12 @@ class ClashConfiguration(BaseSubscription):
         clash_template_content: str | None = None,
         user_agent_template_content: str | None = None,
         grpc_user_agent_template_content: str | None = None,
+        general_auth: GeneralAuthSettings | None = None,
     ):
         super().__init__(
             user_agent_template_content=user_agent_template_content,
             grpc_user_agent_template_content=grpc_user_agent_template_content,
+            general_auth=general_auth,
         )
         self.clash_template_content = clash_template_content
         self.data = {
@@ -595,11 +598,13 @@ class ClashMetaConfiguration(ClashConfiguration):
         clash_template_content: str | None = None,
         user_agent_template_content: str | None = None,
         grpc_user_agent_template_content: str | None = None,
+        general_auth: GeneralAuthSettings | None = None,
     ):
         super().__init__(
             clash_template_content=clash_template_content,
             user_agent_template_content=user_agent_template_content,
             grpc_user_agent_template_content=grpc_user_agent_template_content,
+            general_auth=general_auth,
         )
         # Override protocol handlers to include vless
         self.protocol_handlers = {

--- a/app/subscription/clash.py
+++ b/app/subscription/clash.py
@@ -1,5 +1,6 @@
 from random import choice
 
+import yaml
 from pydantic import BaseModel
 
 from app.models.proxy import GeneralAuthSettings
@@ -30,6 +31,9 @@ class ClashConfiguration(BaseSubscription):
             general_auth=general_auth,
         )
         self.clash_template_content = clash_template_content
+        self.template_handlers = {
+            "authentication": self._configure_authentication,
+        }
         self.data = {
             "proxies": [],
             "proxy-groups": [],
@@ -60,10 +64,39 @@ class ClashConfiguration(BaseSubscription):
         }
 
     def render(self):
-        return render_template_string(
+        rendered = render_template_string(
             self.clash_template_content,
             {"conf": self.data, "proxy_remarks": self.proxy_remarks},
         )
+        if self.general_auth is None:
+            return rendered
+
+        config = yaml.safe_load(rendered)
+        return yaml.dump(
+            self._configure_template(config),
+            sort_keys=False,
+            allow_unicode=True,
+        )
+
+    def _configure_template(self, config: dict | None) -> dict | None:
+        if self.general_auth is None or not isinstance(config, dict):
+            return config
+
+        for field, handler in self.template_handlers.items():
+            if field in config:
+                handler(config[field])
+
+        return config
+
+    def _configure_authentication(self, authentication: object) -> None:
+        credentials = self.general_auth
+        if credentials is None or not isinstance(authentication, list):
+            return
+
+        replacement = f"{credentials.username}:{credentials.password}"
+        for index, value in enumerate(authentication):
+            if value == ":":
+                authentication[index] = replacement
 
     def __str__(self) -> str:
         return self.render()

--- a/app/subscription/links.py
+++ b/app/subscription/links.py
@@ -4,6 +4,7 @@ import urllib.parse as urlparse
 from random import choice
 from urllib.parse import quote
 
+from app.models.proxy import GeneralAuthSettings
 from app.models.subscription import (
     GRPCTransportConfig,
     KCPTransportConfig,
@@ -24,10 +25,12 @@ class StandardLinks(BaseSubscription):
         self,
         user_agent_template_content: str | None = None,
         grpc_user_agent_template_content: str | None = None,
+        general_auth: GeneralAuthSettings | None = None,
     ):
         super().__init__(
             user_agent_template_content=user_agent_template_content,
             grpc_user_agent_template_content=grpc_user_agent_template_content,
+            general_auth=general_auth,
         )
         self.links = []
 

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -9,6 +9,7 @@ from jdatetime import date as jd
 from app.core.hosts import host_manager
 from app.db.crud.wireguard import pick_peer_ip_for_inbound
 from app.db.models import UserStatus
+from app.models.proxy import GeneralAuthSettings
 from app.models.status_emojis import STATUS_EMOJIS
 from app.models.subscription import SubscriptionInboundData
 from app.models.user import UsersResponseWithInbounds
@@ -34,6 +35,7 @@ SERVER_IPV6 = "[::1]"
 def _build_subscription_config(
     config_format: str,
     client_templates: dict[str, str],
+    general_auth: GeneralAuthSettings,
 ) -> (
     StandardLinks
     | XrayConfiguration
@@ -47,6 +49,7 @@ def _build_subscription_config(
     common_kwargs = {
         "user_agent_template_content": client_templates["USER_AGENT_TEMPLATE"],
         "grpc_user_agent_template_content": client_templates["GRPC_USER_AGENT_TEMPLATE"],
+        "general_auth": general_auth,
     }
 
     if config_format == "links":
@@ -91,7 +94,7 @@ async def generate_subscription(
 
     client_templates = await subscription_client_templates()
     xray_template_overrides = await subscription_xray_templates() if config_format == "xray" else None
-    conf = _build_subscription_config(config_format, client_templates)
+    conf = _build_subscription_config(config_format, client_templates, user.proxy_settings.general_auth)
     if conf is None:
         raise ValueError(f'Unsupported format "{config_format}"')
 
@@ -401,6 +404,7 @@ async def _prepare_download_settings(
             xray_template_content=client_templates["XRAY_SUBSCRIPTION_TEMPLATE"],
             user_agent_template_content=client_templates["USER_AGENT_TEMPLATE"],
             grpc_user_agent_template_content=client_templates["GRPC_USER_AGENT_TEMPLATE"],
+            general_auth=conf.general_auth,
         )
         return xc._download_config(download_copy, link_format=True)
 

--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -2,6 +2,7 @@ import json
 import re
 from random import choice
 
+from app.models.proxy import GeneralAuthSettings
 from app.models.subscription import (
     GRPCTransportConfig,
     SubscriptionInboundData,
@@ -20,10 +21,12 @@ class SingBoxConfiguration(BaseSubscription):
         singbox_template_content: str | None = None,
         user_agent_template_content: str | None = None,
         grpc_user_agent_template_content: str | None = None,
+        general_auth: GeneralAuthSettings | None = None,
     ):
         super().__init__(
             user_agent_template_content=user_agent_template_content,
             grpc_user_agent_template_content=grpc_user_agent_template_content,
+            general_auth=general_auth,
         )
         self.config = json.loads(singbox_template_content) if singbox_template_content else {}
         self.config.setdefault("endpoints", [])

--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -32,6 +32,13 @@ class SingBoxConfiguration(BaseSubscription):
         self.config.setdefault("endpoints", [])
         self.config.setdefault("outbounds", [])
 
+        self.template_inbound_handlers = {
+            "mixed": self._configure_mixed,
+            "socks": self._configure_socks,
+            "http": self._configure_http,
+        }
+        self._configure_inbounds(self.config)
+
         # Registry for transport handlers
         self.transport_handlers = {
             "http": self._transport_http,
@@ -114,6 +121,51 @@ class SingBoxConfiguration(BaseSubscription):
                 self.add_endpoint(built)
             else:
                 self.add_outbound(built)
+
+    # ========== Inbound Configurators (Registry Methods) ==========
+
+    def _configure_inbounds(self, config: dict) -> None:
+        if self.general_auth is None:
+            return
+
+        inbounds = config.get("inbounds")
+        if not isinstance(inbounds, list):
+            return
+
+        for inbound in inbounds:
+            if not isinstance(inbound, dict):
+                continue
+
+            handler = self.template_inbound_handlers.get(inbound.get("type"))
+            if handler is not None:
+                handler(inbound)
+
+    def _configure_mixed(self, inbound: dict) -> None:
+        self._replace_user_placeholders(inbound.get("users"))
+
+    def _configure_socks(self, inbound: dict) -> None:
+        self._replace_user_placeholders(inbound.get("users"))
+
+    def _configure_http(self, inbound: dict) -> None:
+        self._replace_user_placeholders(inbound.get("users"))
+
+    def _replace_user_placeholders(self, users: object) -> bool:
+        credentials = self.general_auth
+        if credentials is None or not isinstance(users, list):
+            return False
+
+        replaced = False
+        for user in users:
+            if not isinstance(user, dict):
+                continue
+            if user.get("username") != "" or user.get("password") != "":
+                continue
+
+            user["username"] = credentials.username
+            user["password"] = credentials.password
+            replaced = True
+
+        return replaced
 
     # ========== Transport Handlers ==========
 

--- a/app/subscription/xray.py
+++ b/app/subscription/xray.py
@@ -3,6 +3,7 @@ from random import choice
 
 from pydantic import BaseModel
 
+from app.models.proxy import GeneralAuthSettings
 from app.models.subscription import (
     GRPCTransportConfig,
     KCPTransportConfig,
@@ -24,10 +25,12 @@ class XrayConfiguration(BaseSubscription):
         xray_template_content: str | None = None,
         user_agent_template_content: str | None = None,
         grpc_user_agent_template_content: str | None = None,
+        general_auth: GeneralAuthSettings | None = None,
     ):
         super().__init__(
             user_agent_template_content=user_agent_template_content,
             grpc_user_agent_template_content=grpc_user_agent_template_content,
+            general_auth=general_auth,
         )
         self.config = []
         self.template = json.loads(xray_template_content) if xray_template_content else {}

--- a/app/subscription/xray.py
+++ b/app/subscription/xray.py
@@ -35,6 +35,13 @@ class XrayConfiguration(BaseSubscription):
         self.config = []
         self.template = json.loads(xray_template_content) if xray_template_content else {}
 
+        # Registry for template handlers
+        self.template_inbound_handlers = {
+            "socks": self._configure_socks,
+            "http": self._configure_http,
+        }
+        self._configure_inbounds(self.template)
+
         # Registry for transport handlers
         self.transport_handlers = {
             "ws": self._transport_ws,
@@ -60,8 +67,7 @@ class XrayConfiguration(BaseSubscription):
             "wireguard": self._build_wireguard,
         }
 
-    def add_config(self, remarks, outbounds, template_content: str | None = None):
-        json_template = json.loads(template_content) if template_content is not None else self.template.copy()
+    def add_config(self, remarks, outbounds, json_template):
         json_template["remarks"] = remarks
         json_template["outbounds"] = outbounds + json_template["outbounds"]
         self.config.append(json_template)
@@ -97,7 +103,64 @@ class XrayConfiguration(BaseSubscription):
         else:
             all_outbounds = [result]
 
-        self.add_config(remarks=remark, outbounds=all_outbounds, template_content=template_content)
+        if template_content is not None:
+            json_template = json.loads(template_content)
+            self._configure_inbounds(json_template)
+        else:
+            json_template = self.template.copy()
+
+        self.add_config(remarks=remark, outbounds=all_outbounds, json_template=json_template)
+
+    # ========== Inbound Configurators (Registry Methods) ==========
+
+    def _configure_inbounds(self, config: dict) -> None:
+        if self.general_auth is None:
+            return
+
+        inbounds = config.get("inbounds")
+        if not isinstance(inbounds, list):
+            return
+
+        for inbound in inbounds:
+            if not isinstance(inbound, dict):
+                continue
+
+            handler = self.template_inbound_handlers.get(inbound.get("protocol"))
+            if handler is not None:
+                handler(inbound)
+
+    def _configure_socks(self, inbound: dict) -> None:
+        settings = inbound.get("settings")
+        if not isinstance(settings, dict):
+            return
+
+        if self._replace_user_placeholders(settings.get("users")):
+            settings["auth"] = "password"
+
+    def _configure_http(self, inbound: dict) -> None:
+        settings = inbound.get("settings")
+        if not isinstance(settings, dict):
+            return
+
+        self._replace_user_placeholders(settings.get("users"))
+
+    def _replace_user_placeholders(self, users: object) -> bool:
+        credentials = self.general_auth
+        if credentials is None or not isinstance(users, list):
+            return False
+
+        replaced = False
+        for user in users:
+            if not isinstance(user, dict):
+                continue
+            if user.get("user") != "" or user.get("pass") != "":
+                continue
+
+            user["user"] = credentials.username
+            user["pass"] = credentials.password
+            replaced = True
+
+        return replaced
 
     # ========== Transport Handlers (Registry Methods) ==========
 


### PR DESCRIPTION
## Summary

Adds per-user credentials for local SOCKS/HTTP proxy inbounds in generated subscriptions.

Russian VPN-detection guidance[3] reportedly includes probing publicly accessible SOCKS/HTTP proxies to discover their external IP address. Static credentials hardcoded in client templates therefore expose every user to the same probe. This change generates and persists unique credentials per user, backfills existing users through a migration, and substitutes them only into explicit empty placeholders in Xray, sing-box, and Mihomo/Clash templates.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests / CI

## Checklist

- [x] I tested the change locally or explained why it cannot be tested.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated documentation, translations, or examples if needed.
- [x] I checked database migrations when models or schema changed.
- [x] I did not include secrets, tokens, private keys, or unrelated changes.

## Testing

Tested the whole flow on XRAY templates. sing-box and clash templates were statically validated via LLM.

## Screenshots

N/A

## Notes for reviewers

Credentials are injected only when templates contain intentionally empty credential placeholders, so existing non-placeholder template values remain unchanged.

Background and sources (in russian):
1. https://habr.com/ru/articles/1020080
2. https://habr.com/ru/articles/1022422/
3. https://t.me/ruitunion/893
4. https://publish.obsidian.md/zapret/VLESS-SOCKS5-vulnerability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added general authentication settings with automatically generated username and password credentials.
  * Generated Clash, Sing-box, and Xray configurations now apply configured credentials to supported HTTP and SOCKS authentication placeholders.
  * Authentication settings are carried through subscription and proxy configuration generation.
* **Bug Fixes**
  * Preserved templates without authentication placeholders when general authentication is not configured.
  * Improved handling of authentication credentials across supported configuration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->